### PR TITLE
Remove dependency on utils package for kafka example

### DIFF
--- a/cmd/examples/kafka.go
+++ b/cmd/examples/kafka.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/ONSdigital/dp-publish-pipeline/utils"
 	"github.com/ONSdigital/go-ns/kafka"
 	"github.com/ONSdigital/go-ns/log"
 )
@@ -14,14 +13,11 @@ import (
 func main() {
 	log.Namespace = "kafka-example"
 
-	brokers := utils.GetEnvironmentVariableAsArray("KAFKA_ADDR", "localhost:9092")
-	consumedTopic := utils.GetEnvironmentVariable("CONSUMED_TOPIC", "input")
-	producedTopic := utils.GetEnvironmentVariable("PRODUCED_TOPIC", "output")
-	maxMessageSize, err := utils.GetEnvironmentVariableInt("KAFKA_MESSAGE_SIZE", 50*1024*1024) // default to 50MB
-	if err != nil {
-		log.ErrorC("Could not create consumer", err, nil)
-		panic("Could not create consumer")
-	}
+	var brokers []string
+	brokers = append(brokers, "localhost:9092")
+	consumedTopic := "input"
+	producedTopic := "output"
+	maxMessageSize := 50 * 1024 * 1024 // 50MB
 
 	log.Info(fmt.Sprintf("Starting topics: %q -> stdout, stdin -> %q", consumedTopic, producedTopic), nil)
 


### PR DESCRIPTION
utils package is not currently open sourced and the simplest way of setting
up kafka variables is to hardcode them into this example application. If a developer
wants to use environment variables this can be done several different
ways but should not effect an example app of how to use this go-ns kafka library.