### PR TITLE
Feature/unstub dataset api

### DIFF
--- a/clients/dataset/data.go
+++ b/clients/dataset/data.go
@@ -1,15 +1,61 @@
 package dataset
 
-// Model represents a response model from the dataset api
+// Model represents a response dataset model from the dataset api
 type Model struct {
-	ID          string  `json:"id"`
-	Title       string  `json:"title"`
-	URL         string  `json:"url"`
-	ReleaseDate string  `json:"release_date"`
-	NextRelease string  `json:"next_release"`
-	Edition     string  `json:"edition"`
-	Version     string  `json:"version"`
-	Contact     Contact `json:"contact"`
+	CollectionID string    `json:"collection_id"`
+	Contact      Contact   `json:"contact"`
+	Description  string    `json:"description"`
+	Links        Links     `json:"links"`
+	NextRelease  string    `json:"next_release"`
+	Periodicity  string    `json:"yearly"`
+	Publisher    Publisher `json:"publisher"`
+	State        string    `json:"state"`
+	Theme        string    `json:"theme"`
+	Title        string    `json:"title"`
+}
+
+// Version represents a version within a dataset
+type Version struct {
+	CollectionID string `json:"collection_id"`
+	Edition      string `json:"edition"`
+	ID           string `json:"id"`
+	InstanceID   string `json:"instance_id"`
+	License      string `json:"license"`
+	Links        Links  `json:"links"`
+	ReleaseDate  string `json:"release_date"`
+	State        string `json:"date"`
+}
+
+// Edition represents an edition within a dataset
+type Edition struct {
+	Edition string `json:"edition"`
+	ID      string `json:"id"`
+	Links   Links  `json:"links"`
+	State   string `json:"state"`
+}
+
+// Publisher represents the publisher within the dataset
+type Publisher struct {
+	URL  string `json:"href"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// Links represent the Links within a dataset model
+type Links struct {
+	Dataset       Link `json:"dataset"`
+	Dimensions    Link `json:"dimensions"`
+	Edition       Link `json:"edition"`
+	Editions      Link `json:"editions"`
+	LatestVersion Link `json:"latest_version"`
+	Versions      Link `json:"versions"`
+	Self          Link `json:"self"`
+}
+
+// Link represents a single link within a dataset model
+type Link struct {
+	URL string `json:"href"`
+	ID  string `json:"id,omitempty"`
 }
 
 // Contact represents a response model within a dataset
@@ -17,10 +63,4 @@ type Contact struct {
 	Name      string `json:"name"`
 	Telephone string `json:"telephone"`
 	Email     string `json:"email"`
-}
-
-// Metadata represents metadata from dataset
-type Metadata struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
 }

--- a/clients/filter/filter.go
+++ b/clients/filter/filter.go
@@ -165,6 +165,32 @@ func (c *Client) CreateJob(datasetFilterID string) (string, error) {
 	return fj.FilterID, nil
 }
 
+// UpdateJob will update a job with a given filter model
+func (c *Client) UpdateJob(m Model) error {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+
+	uri := fmt.Sprintf("%s/filters/%s", c.url, m.FilterID)
+
+	req, err := http.NewRequest("PUT", uri, bytes.NewBuffer(b))
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.cli.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return ErrInvalidFilterAPIResponse{http.StatusOK, resp.StatusCode, uri}
+	}
+
+	return nil
+}
+
 // AddDimensionValue adds a particular value to a filter job for a given filterID
 // and name
 func (c *Client) AddDimensionValue(filterID, name, value string) error {


### PR DESCRIPTION
### This is a big'un

To test this, you will need the following services running:

- dp-frontend-router
- dp-frontend-dataset-controller
- dp-frontend-filter-dataset-controller
- dp-frontend-router
- sixteens
- dp-frontend-renderer
- zebedee
- babbage
- dp-dataset-api
- dp-filter-api
- dp-import-api
- dp-recipe-api
- dp-code-list-api
- dp-hierarchy-api
- dp-dimension-extractor
- dp-dimension-importer
- dp-observation-exporter
- dp-observation-importer
- dp-import-tracker
- dp-dataset-exporter

You will then need to export the CPI dataset locally. If you haven't done this already and don't know how to, then I will help with this!

Once you have imported the dataset, then in mongodb, you will have a datasets collection. Use the _id field in mongodb to create a data.json file which looks like:

```
{
	"description": {
		"datasetId": "95c4669b-3ae9-4ba7-b690-87e890a1c67c"
	},
	"type": "api_dataset_landing_page"
}
```

and put it in your zebedee-content path under:

`master/employmentandlabourmarket/peopleinwork/workplacedisputesandworkingconditions/datasets/labourdisputesbysectorlabd02/data.json`

Navigate your browser to 

http://localhost:20000/employmentandlabourmarket/peopleinwork/workplacedisputesandworkingconditions/datasets/labourdisputesbysectorlabd02

and verify that you are redirected to

`http://localhost:20000/datasets/95c4669b-3ae9-4ba7-b690-87e890a1c67c`

You should then have a `Filter And Download` button appear. Click on it and add some dimension values to your filter job.

Verify that the journey works as expected. Verify when you click on Preview and Download, that a real csv is generated for you. Note that the values in the csv will not yet match the filters you have selected. This will follow in the next sprint








