### PR TITLE
Feature/robust kafka

### DIFF
--- a/cmd/kafka-example/main.go
+++ b/cmd/kafka-example/main.go
@@ -2,15 +2,20 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"sync/atomic"
 
 	"context"
+	"time"
+
 	"github.com/ONSdigital/go-ns/kafka"
 	"github.com/ONSdigital/go-ns/log"
-	"time"
 )
+
+const timeOut = 5 * time.Second
 
 func main() {
 	log.Namespace = "kafka-example"
@@ -27,23 +32,26 @@ func main() {
 	}
 	maxMessageSize := 50 * 1024 * 1024 // 50MB
 
-	log.Info(fmt.Sprintf("Starting topics: %q -> stdout, stdin -> %q", consumedTopic, producedTopic), nil)
+	log.Info(fmt.Sprintf("[KAFKA-TEST] Starting topics: %q -> stdout, stdin -> %q", consumedTopic, producedTopic), nil)
 
 	kafka.SetMaxMessageSize(int32(maxMessageSize))
 	producer, err := kafka.NewProducer(brokers, producedTopic, maxMessageSize)
 	if err != nil {
-		log.ErrorC("Could not create producer", err, nil)
-		panic("Could not create producer")
+		log.ErrorC("[KAFKA-TEST] Could not create producer", err, nil)
+		panic("[KAFKA-TEST] Could not create producer")
 	}
+
 	consumer, err := kafka.NewConsumerGroup(brokers, consumedTopic, log.Namespace, kafka.OffsetNewest)
 	if err != nil {
-		log.ErrorC("Could not create consumer", err, nil)
-		panic("Could not create consumer")
+		log.ErrorC("[KAFKA-TEST] Could not create consumer", err, nil)
+		panic("[KAFKA-TEST] Could not create consumer")
 	}
 
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt)
 	stdinChannel := make(chan string)
+	readyToCloseConsumer := make(chan bool)
+	readyToCloseProducer := make(chan bool)
 
 	go func(ch chan string) {
 		reader := bufio.NewReader(os.Stdin)
@@ -57,40 +65,82 @@ func main() {
 		close(ch)
 	}(stdinChannel)
 
-	shutdownGracefully := func() {
-
-		// give the app 3 seconds to close gracefully before killing it.
-		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-		defer cancel()
-
-		producer.Close(ctx)
-		consumer.Close(ctx)
-		log.Info("Service kafka example stopped", nil)
-		os.Exit(1)
-	}
-
-	for {
-		select {
-		case consumedMessage := <-consumer.Incoming():
-			consumedData := consumedMessage.GetData()
-			log.Info("Message consumed", log.Data{
-				"messageString": string(consumedData),
-				"messageRaw":    consumedData,
-				"messageLen":    len(consumedData),
-			})
-			consumedMessage.Commit()
-		case consumerError := <-consumer.Errors():
-			log.Error(fmt.Errorf("Aborting"), log.Data{"messageReceived": consumerError})
-			shutdownGracefully()
-		case producerError := <-producer.Errors():
-			log.Error(fmt.Errorf("Aborting"), log.Data{"messageReceived": producerError})
-			shutdownGracefully()
-		case stdinLine := <-stdinChannel:
-			producer.Output() <- []byte(stdinLine)
-			log.Info("Message output", log.Data{"messageSent": stdinLine})
-		case <-signals:
-			log.Info("Quitting after signal", nil)
-			shutdownGracefully()
+	done := make(chan bool)
+	go func() {
+		for {
+			select {
+			case consumedMessage := <-consumer.Incoming():
+				log.Info("[KAFKA-TEST] Received message", nil)
+				consumedData := consumedMessage.GetData()
+				log.Info("[KAFKA-TEST] Message consumed", log.Data{
+					"messageString": string(consumedData),
+					"messageRaw":    consumedData,
+					"messageLen":    len(consumedData),
+				})
+				time.Sleep(1 * time.Second)
+				producer.Output() <- consumedData
+				consumedMessage.Commit()
+				log.Info("[KAFKA-TEST] committed message", log.Data{"messageString": string(consumedData)})
+			case consumerError := <-consumer.Errors():
+				log.Error(fmt.Errorf("[KAFKA-TEST] Aborting consumer"), log.Data{"messageReceived": consumerError})
+				close(done)
+				return
+			case producerError := <-producer.Errors():
+				log.Error(fmt.Errorf("[KAFKA-TEST] Aborting producer"), log.Data{"messageReceived": producerError})
+				close(done)
+				return
+			case stdinLine := <-stdinChannel:
+				producer.Output() <- []byte(stdinLine)
+				log.Info("[KAFKA-TEST] Message output", log.Data{"messageSent": stdinLine})
+			}
 		}
+	}()
+
+	select {
+	case <-done:
+		log.Info("[KAFKA-TEST] Quitting after done was closed", nil)
+	case <-signals:
+		log.Info("[KAFKA-TEST] Quitting after signal", nil)
 	}
+
+	// give the app 3 seconds to close gracefully before killing it.
+	ctx, cancel := context.WithTimeout(context.Background(), timeOut)
+	defer cancel()
+
+	waitGroup := int32(0)
+
+	// background a wait for the instance handler to stop
+	atomic.AddInt32(&waitGroup, 1)
+	go func() {
+		log.Info("[KAFKA-TEST] Attempting to close kafka consumer group", nil)
+		consumer.Close(ctx, readyToCloseConsumer, readyToCloseProducer)
+		atomic.AddInt32(&waitGroup, -1)
+
+		log.Info("[KAFKA-TEST] Closed kafka consumer", nil)
+	}()
+
+	// background a wait for the instance handler to stop
+	atomic.AddInt32(&waitGroup, 1)
+	go func() {
+		log.Info("[KAFKA-TEST] Stop writing to producer", nil)
+		<-readyToCloseProducer
+		producer.Close(ctx)
+		atomic.AddInt32(&waitGroup, -1)
+		log.Info("[KAFKA-TEST] Closed kafka producer", nil)
+		// Allow service to commit to consumer before closing consumerGroup
+		readyToCloseConsumer <- true
+	}()
+
+	// setup a timer to zero waitGroup after timeout
+	go func() {
+		<-time.After(timeOut)
+		log.Error(errors.New("[KAFKA-TEST] timeout while shutting down"), nil)
+		atomic.AddInt32(&waitGroup, -atomic.LoadInt32(&waitGroup))
+	}()
+
+	for atomic.LoadInt32(&waitGroup) > 0 {
+	}
+
+	log.Info("[KAFKA-TEST] Service kafka example stopped", nil)
+	os.Exit(1)
 }

--- a/cmd/kafka-example/main.go
+++ b/cmd/kafka-example/main.go
@@ -2,11 +2,9 @@ package main
 
 import (
 	"bufio"
-	"fmt"
+	"context"
 	"os"
 	"os/signal"
-
-	"context"
 	"time"
 
 	"github.com/ONSdigital/go-ns/kafka"
@@ -47,7 +45,8 @@ func main() {
 		panic(err)
 	}
 
-	log.Info(fmt.Sprintf("[KAFKA-TEST] Starting topics: %q -> stdout, stdin -> %q", cfg.ConsumedTopic, cfg.ProducedTopic), nil)
+	log.Info("[KAFKA-TEST] Starting (consumer sent to stdout, stdin sent to producer)",
+		log.Data{"consumed_group": cfg.ConsumedGroup, "consumed_topic": cfg.ConsumedTopic, "produced_topic": cfg.ProducedTopic})
 
 	kafka.SetMaxMessageSize(int32(cfg.KafkaMaxBytes))
 	producer, err := kafka.NewProducer(cfg.Brokers, cfg.ProducedTopic, cfg.KafkaMaxBytes)

--- a/cmd/kafka-example/main.go
+++ b/cmd/kafka-example/main.go
@@ -102,7 +102,8 @@ func main() {
 				consumeCount++
 				log.Info("[KAFKA-TEST] Received message", log.Data{"consumeCount": consumeCount, "consumeMax": cfg.ConsumeMax})
 				consumedData := consumedMessage.GetData()
-				sleep := 500*time.Millisecond + cfg.TimeOut
+				sleep := 0 * time.Millisecond
+				// sleep = 500*time.Millisecond + cfg.TimeOut
 				log.Info("[KAFKA-TEST] Message consumed", log.Data{
 					"messageString": string(consumedData),
 					"messageRaw":    consumedData,

--- a/cmd/kafka-example/main.go
+++ b/cmd/kafka-example/main.go
@@ -5,58 +5,59 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"strconv"
 
 	"context"
 	"time"
 
 	"github.com/ONSdigital/go-ns/kafka"
 	"github.com/ONSdigital/go-ns/log"
+	"github.com/kelseyhightower/envconfig"
 )
 
-const timeOut = 5 * time.Second
+type Config struct {
+	Brokers       []string      `envconfig:"KAFKA_ADDR"`
+	KafkaMaxBytes int           `envconfig:"KAFKA_MAX_BYTES"`
+	ConsumedTopic string        `envconfig:"KAFKA_CONSUMED_TOPIC"`
+	ConsumedGroup string        `envconfig:"KAFKA_CONSUMED_GROUP"`
+	ProducedTopic string        `envconfig:"KAFKA_PRODUCED_TOPIC"`
+	ConsumeMax    int           `envconfig:"KAFKA_CONSUME_MAX"`
+	KafkaSync     bool          `envconfig:"KAFKA_SYNC"`
+	TimeOut       time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
+	Chomp         bool          `envconfig:"CHOMP_MSG"`
+}
 
 func main() {
 	log.Namespace = "kafka-example"
+	cfg := &Config{
+		Brokers:       []string{"locahost:9092"},
+		KafkaMaxBytes: 50 * 1024 * 1024,
+		KafkaSync:     true,
+		ConsumedGroup: log.Namespace,
+		ConsumedTopic: "input",
+		ProducedTopic: "output",
+		ConsumeMax:    0,
+		TimeOut:       5 * time.Second,
+		Chomp:         false,
+	}
+	if err := envconfig.Process("", cfg); err != nil {
+		panic(err)
+	}
 
-	brokers := []string{os.Getenv("KAFKA_ADDR")}
-	if brokers[0] == "" {
-		brokers = []string{"localhost:9092"}
-	}
-	consumedTopic := os.Getenv("KAFKA_CONSUMED_TOPIC")
-	if consumedTopic == "" {
-		consumedTopic = "input"
-	}
-	consumedGroup := os.Getenv("KAFKA_CONSUMED_GROUP")
-	if consumedGroup == "" {
-		consumedGroup = log.Namespace
-	}
-	producedTopic := os.Getenv("KAFKA_PRODUCED_TOPIC")
-	if producedTopic == "" {
-		producedTopic = "output"
-	}
-	consumeCount := 0
-	consumeMax := 0
-	maxMessagesString := os.Getenv("KAFKA_CONSUME_MAX")
-	if maxMessagesString != "" {
-		var err error
-		consumeMax, err = strconv.Atoi(maxMessagesString)
-		if err != nil {
-			panic(err)
-		}
-	}
-	maxMessageSize := 50 * 1024 * 1024 // 50MB
+	log.Info(fmt.Sprintf("[KAFKA-TEST] Starting topics: %q -> stdout, stdin -> %q", cfg.ConsumedTopic, cfg.ProducedTopic), nil)
 
-	log.Info(fmt.Sprintf("[KAFKA-TEST] Starting topics: %q -> stdout, stdin -> %q", consumedTopic, producedTopic), nil)
-
-	kafka.SetMaxMessageSize(int32(maxMessageSize))
-	producer, err := kafka.NewProducer(brokers, producedTopic, maxMessageSize)
+	kafka.SetMaxMessageSize(int32(cfg.KafkaMaxBytes))
+	producer, err := kafka.NewProducer(cfg.Brokers, cfg.ProducedTopic, cfg.KafkaMaxBytes)
 	if err != nil {
 		log.ErrorC("[KAFKA-TEST] Could not create producer", err, nil)
 		panic("[KAFKA-TEST] Could not create producer")
 	}
 
-	consumer, err := kafka.NewConsumerGroup(brokers, consumedTopic, consumedGroup, kafka.OffsetNewest)
+	var consumer *kafka.ConsumerGroup
+	if cfg.KafkaSync {
+		consumer, err = kafka.NewSyncConsumer(cfg.Brokers, cfg.ConsumedTopic, cfg.ConsumedGroup, kafka.OffsetNewest)
+	} else {
+		consumer, err = kafka.NewConsumerGroup(cfg.Brokers, cfg.ConsumedTopic, cfg.ConsumedGroup, kafka.OffsetNewest)
+	}
 	if err != nil {
 		log.ErrorC("[KAFKA-TEST] Could not create consumer", err, nil)
 		panic("[KAFKA-TEST] Could not create consumer")
@@ -68,6 +69,7 @@ func main() {
 
 	eventLoopContext, eventLoopCancel := context.WithCancel(context.Background())
 	eventLoopDone := make(chan bool)
+	consumeCount := 0
 
 	go func(ch chan string) {
 		reader := bufio.NewReader(os.Stdin)
@@ -75,6 +77,9 @@ func main() {
 			line, err := reader.ReadString('\n')
 			if err != nil {
 				break
+			}
+			if cfg.Chomp {
+				line = line[:len(line)-1]
 			}
 			ch <- line
 		}
@@ -88,22 +93,36 @@ func main() {
 		defer close(eventLoopDone)
 		for {
 			select {
+			case <-time.After(1 * time.Second):
+				log.Trace("[KAFKA-TEST] tick", nil)
 			case <-eventLoopContext.Done():
+				log.Trace("[KAFKA-TEST] Event loop context done", log.Data{"eventLoopContextErr": eventLoopContext.Err()})
 				return
 			case consumedMessage := <-consumer.Incoming():
-				log.Info("[KAFKA-TEST] Received message", nil)
+				consumeCount++
+				log.Info("[KAFKA-TEST] Received message", log.Data{"consumeCount": consumeCount, "consumeMax": cfg.ConsumeMax})
 				consumedData := consumedMessage.GetData()
+				sleep := 500*time.Millisecond + cfg.TimeOut
 				log.Info("[KAFKA-TEST] Message consumed", log.Data{
 					"messageString": string(consumedData),
 					"messageRaw":    consumedData,
 					"messageLen":    len(consumedData),
+					"consumeCount":  consumeCount,
+					"sleep":         sleep,
 				})
+				time.Sleep(sleep)
+				log.Trace("[KAFKA-TEST] done sleeping", nil)
 				producer.Output() <- consumedData
-				consumedMessage.Commit()
-				log.Info("[KAFKA-TEST] committed message", log.Data{"messageString": string(consumedData)})
-				consumeCount++
-				if consumeCount == consumeMax {
-					log.Trace("consumed max - exiting eventLoop", nil)
+				if cfg.KafkaSync {
+					log.Trace("[KAFKA-TEST] pre-release", nil)
+					consumer.CommitAndRelease(consumedMessage)
+					log.Trace("[KAFKA-TEST] postrelease", nil)
+				} else {
+					consumedMessage.Commit()
+				}
+				log.Info("[KAFKA-TEST] committed message", log.Data{"consumeCount": consumeCount})
+				if consumeCount == cfg.ConsumeMax {
+					log.Trace("[KAFKA-TEST] consumed max - exiting eventLoop", nil)
 					return
 				}
 			case stdinLine := <-stdinChannel:
@@ -113,41 +132,46 @@ func main() {
 		}
 	}()
 
-	// block until a fatal error/signal or eventLoopDone - then proceed to shutdown
+	// block until a fatal error, signal or eventLoopDone - then proceed to shutdown
 	select {
 	case <-eventLoopDone:
 		log.Info("[KAFKA-TEST] Quitting after event loop aborted", nil)
-	case <-signals:
-		log.Info("[KAFKA-TEST] os signal received", nil)
+	case sig := <-signals:
+		log.Info("[KAFKA-TEST] Quitting after OS signal", log.Data{"signal": sig})
 	case consumerError := <-consumer.Errors():
-		log.Error(fmt.Errorf("[KAFKA-TEST] Aborting consumer"), log.Data{"messageReceived": consumerError})
+		log.ErrorC("[KAFKA-TEST] Aborting consumer", consumerError, nil)
 	case producerError := <-producer.Errors():
-		log.Error(fmt.Errorf("[KAFKA-TEST] Aborting producer"), log.Data{"messageReceived": producerError})
+		log.ErrorC("[KAFKA-TEST] Aborting producer", producerError, nil)
 	}
 
 	// give the eventLoop time to close gracefully before exiting
-	ctx, cancel := context.WithTimeout(context.Background(), timeOut)
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.TimeOut)
 
 	// background graceful shutdown
 	go func() {
-		log.Info("[KAFKA-TEST] Attempting to stop listening to kafka consumer group", nil)
+		log.Info("[KAFKA-TEST] Stopping kafka consumer listener", nil)
 		consumer.StopListeningToConsumer(ctx)
-		log.Info("[KAFKA-TEST] Successfully stopped listening to kafka consumer group", nil)
+		log.Info("[KAFKA-TEST] Stopped kafka consumer listener", nil)
 		eventLoopCancel()
+		// wait for eventLoopDone: all in-flight messages have been processed
 		<-eventLoopDone
-		log.Info("[KAFKA-TEST] Attempting to close kafka producer", nil)
+		log.Info("[KAFKA-TEST] Closing kafka producer", nil)
 		producer.Close(ctx)
-		log.Info("[KAFKA-TEST] Successfully closed kafka producer", nil)
-		log.Info("[KAFKA-TEST] Attempting to close kafka consumer group", nil)
+		log.Info("[KAFKA-TEST] Closed kafka producer", nil)
+		log.Info("[KAFKA-TEST] Closing kafka consumer", nil)
 		consumer.Close(ctx)
-		log.Info("[KAFKA-TEST] Successfully closed kafka consumer group", nil)
+		log.Info("[KAFKA-TEST] Closed kafka consumer", nil)
 
-		log.Info("[KAFKA-TEST] Successfully shutdown", nil)
-		cancel() // stop timeout
+		log.Info("[KAFKA-TEST] Done shutdown - cancelling timeout context", nil)
+		cancel() // stop timer
 	}()
 
-	// wait for timeout or success
+	// wait for timeout or success (via cancel)
 	<-ctx.Done()
-	log.ErrorC("[KAFKA-TEST] shutdown done", ctx.Err(), nil)
+	if ctx.Err() == context.DeadlineExceeded {
+		log.ErrorC("[KAFKA-TEST]", ctx.Err(), nil)
+	} else {
+		log.Info("[KAFKA-TEST] Done shutdown gracefully", log.Data{"context": ctx.Err()})
+	}
 	os.Exit(1)
 }

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -3,4 +3,9 @@ Kafka wrapper
 
 Use channels to abstract kafka consumers and producers.
 
+For graceful handling of Closing consumers, it is advised to use the
+`StopListeningToConsumer` method prior to the `Close`method. This will allow
+inflight messages to be completed and successfully call commit so that the
+message does not get replayed once the application restarts.
+
 See the [example source file](../cmd/kafka-example/main.go) for a typical usage.

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -5,4 +5,10 @@ Use channels to abstract kafka consumers and producers.
 
 For graceful handling of Closing consumers, it is advised to use the `StopListeningToConsumer` method prior to the `Close` method. This will allow inflight messages to be completed and successfully call commit so that the message does not get replayed once the application restarts.
 
+It is recommended to use `NewSyncConsumer` - where, when you have read a message from `Incoming()`,
+the listener for messages will block (and not read the next message from kafka)
+until you signal that the message has been consumed (typically with `CommitAndRelease(msg)`).
+Otherwise, if the application gets shutdown (e.g. interrupt signal), and has to be shutdown,
+the consumer may not be shutdown in a timely manner (because it is blocked sending the read message to `Incoming()`).
+
 See the [example source file](../cmd/kafka-example/main.go) for a typical usage.

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -3,9 +3,6 @@ Kafka wrapper
 
 Use channels to abstract kafka consumers and producers.
 
-For graceful handling of Closing consumers, it is advised to use the
-`StopListeningToConsumer` method prior to the `Close`method. This will allow
-inflight messages to be completed and successfully call commit so that the
-message does not get replayed once the application restarts.
+For graceful handling of Closing consumers, it is advised to use the `StopListeningToConsumer` method prior to the `Close`method. This will allow inflight messages to be completed and successfully call commit so that the message does not get replayed once the application restarts.
 
 See the [example source file](../cmd/kafka-example/main.go) for a typical usage.

--- a/kafka/consumer-group.go
+++ b/kafka/consumer-group.go
@@ -9,17 +9,19 @@ import (
 	"github.com/bsm/sarama-cluster"
 )
 
-var tick = time.Millisecond * 4000
+var tick = time.Millisecond * 1500
 
 // ConsumerGroup represents a Kafka consumer group instance.
 type ConsumerGroup struct {
-	consumer *cluster.Consumer
-	incoming chan Message
-	errors   chan error
-	closer   chan struct{}
-	closed   chan struct{}
-	topic    string
-	group    string
+	consumer     *cluster.Consumer
+	incoming     chan Message
+	errors       chan error
+	closer       chan struct{}
+	closed       chan struct{}
+	topic        string
+	group        string
+	sync         bool
+	upstreamDone chan bool
 }
 
 // Incoming provides a channel of incoming messages.
@@ -30,6 +32,21 @@ func (cg ConsumerGroup) Incoming() chan Message {
 // Errors provides a channel of incoming errors.
 func (cg ConsumerGroup) Errors() chan error {
 	return cg.errors
+}
+
+// Release signals that upstream has completed an incoming message
+// i.e. move on to read the next message
+func (cg ConsumerGroup) Release() {
+	cg.upstreamDone <- true
+}
+
+// Release signals the successful completion of a read incoming message
+func (cg ConsumerGroup) CommitAndRelease(msg Message) {
+	log.Trace("pre-commit", nil)
+	msg.Commit()
+	log.Trace("postCommit pre-release", nil)
+	cg.Release()
+	log.Trace("           postRelease", nil)
 }
 
 // StopListeningToConsumer stops any more messages being consumed off kafka topic
@@ -43,13 +60,12 @@ func (cg *ConsumerGroup) StopListeningToConsumer(ctx context.Context) (err error
 
 	select {
 	case <-cg.closed:
-		log.Info("Stopped listening to kafka consumer group", log.Data{"topic": cg.topic, "group": cg.group})
-		return
+		log.Info("StopListeningToConsumer saw closed kafka consumer", log.Data{"topic": cg.topic, "group": cg.group})
 	case <-ctx.Done():
 		err = fmt.Errorf("StopListeningToConsumer context timed out for group[%s] topic[%s]: %s", cg.group, cg.topic, ctx.Err())
 		log.Error(err, nil)
-		return err
 	}
+	return
 }
 
 // Close safely closes the consumer and releases all resources.
@@ -61,7 +77,7 @@ func (cg *ConsumerGroup) Close(ctx context.Context) (err error) {
 		ctx = context.Background()
 	}
 
-	// close(closer) - select avoids panic if already closed
+	// close(closer) - the select{} avoids panic if already closed (by StopListeningToConsumer)
 	select {
 	case <-cg.closer:
 	default:
@@ -76,20 +92,28 @@ func (cg *ConsumerGroup) Close(ctx context.Context) (err error) {
 		if err = cg.consumer.Close(); err != nil {
 			err = fmt.Errorf("Failed to close kafka consumer group for group[%s] topic[%s]: %s", cg.group, cg.topic, err)
 			log.Error(err, nil)
-			return
+		} else {
+			log.Info("Successfully closed kafka consumer group", log.Data{"topic": cg.topic, "group": cg.group})
 		}
-
-		log.Info("Successfully closed kafka consumer group", log.Data{"topic": cg.topic, "group": cg.group})
-		return
 	case <-ctx.Done():
 		err = fmt.Errorf("Shutdown context timed out for group[%s] topic[%s]: %s", cg.group, cg.topic, ctx.Err())
 		log.Error(err, nil)
-		return err
 	}
+	return
 }
 
-// NewConsumerGroup returns a new consumer group using default configuration.
+// NewSyncConsumer returns a new synchronous consumer group using default configuration.
+func NewSyncConsumer(brokers []string, topic string, group string, offset int64) (*ConsumerGroup, error) {
+	return newConsumer(brokers, topic, group, offset, true)
+}
+
+// NewConsumerGroup returns a new asynchronous consumer group using default configuration.
 func NewConsumerGroup(brokers []string, topic string, group string, offset int64) (*ConsumerGroup, error) {
+	return newConsumer(brokers, topic, group, offset, false)
+}
+
+// newConsumer returns a new consumer group using default configuration.
+func newConsumer(brokers []string, topic string, group string, offset int64, sync bool) (*ConsumerGroup, error) {
 
 	config := cluster.NewConfig()
 	config.Group.Return.Notifications = true
@@ -99,52 +123,98 @@ func NewConsumerGroup(brokers []string, topic string, group string, offset int64
 
 	consumer, err := cluster.NewConsumer(brokers, group, []string{topic}, config)
 	if err != nil {
-		return nil, fmt.Errorf("Bad NewConsumer of group[%s] topic[%s]: %s", group, topic, err)
+		return nil, fmt.Errorf("newConsumer error: group[%s] topic[%s]: %s", group, topic, err)
 	}
 
-	cg := ConsumerGroup{
-		consumer: consumer,
-		incoming: make(chan Message),
-		closer:   make(chan struct{}),
-		closed:   make(chan struct{}),
-		errors:   make(chan error),
-		topic:    topic,
-		group:    group,
+	var upstream chan Message
+	if sync {
+		// make the upstream channel buffered, so we can send-and-wait for upstreamDone
+		upstream = make(chan Message, 1)
+	} else {
+		upstream = make(chan Message)
 	}
 
+	cg := &ConsumerGroup{
+		consumer:     consumer,
+		incoming:     upstream,
+		closer:       make(chan struct{}),
+		closed:       make(chan struct{}),
+		errors:       make(chan error),
+		topic:        topic,
+		group:        group,
+		sync:         sync,
+		upstreamDone: make(chan bool),
+	}
+
+	// listener goroutine - listen to consumer.Messages() and upstream them
+	// if this blocks while upstreaming a message, we can shutdown consumer via the following goroutine
 	go func() {
-		log.Info(fmt.Sprintf("Started kafka consumer of topic %q group %q", cg.topic, cg.group), nil)
+		log.Info(fmt.Sprintf("Started kafka consumer listener of topic %q group %q", cg.topic, cg.group), nil)
 		defer close(cg.closed)
-		select {
-		case <-cg.closer:
-			cg.consumer.CommitOffsets()
-			log.Info(fmt.Sprintf("Closing kafka consumer of topic %q group %q", cg.topic, cg.group), nil)
-			return
-		case msg := <-cg.consumer.Messages():
-			cg.Incoming() <- SaramaMessage{msg, cg.consumer}
-		}
-	}()
-
-	go func() {
-		hasBalanced := false
-		for {
+		for looping := true; looping; {
+			log.Trace("listener.....", nil)
 			select {
 			case <-cg.closer:
-				return
+				log.Trace("listener.....CLOSER closed - exiting listener", nil)
+				looping = false
+			case <-time.After(tick):
+				log.Trace("listener.....tick", nil)
+			case msg := <-cg.consumer.Messages():
+				log.Trace("listener.....msg sending upstream, may block...", nil)
+				cg.Incoming() <- SaramaMessage{msg, cg.consumer}
+				if cg.sync {
+					// wait for msg-processed or close-consumer triggers
+					log.Trace("listener.....msg upstreamed - waiting for sync", nil)
+					for loopingForSync := true; loopingForSync; {
+						select {
+						case <-cg.upstreamDone:
+							log.Trace("listener.....sync DONE!", nil)
+							loopingForSync = false
+						// case <-cg.closer:
+						// 	log.Trace("listener.....sync closer triggered", nil)
+						// 	looping = false
+						// 	loopingForSync = false
+						case <-time.After(tick):
+							log.Trace("listener.....sync tick", nil)
+						}
+					}
+				} else {
+					log.Trace("listener.....msg upstreamed", nil)
+				}
+			}
+		}
+		cg.consumer.CommitOffsets()
+		log.Info(fmt.Sprintf("Closed kafka consumer listener of topic %q group %q", cg.topic, cg.group), nil)
+	}()
+
+	// control goroutine - allows us to close consumer even if blocked while upstreaming a message (above)
+	go func() {
+		hasBalanced := false // avoid CommitOffsets() being called before we have balanced (otherwise causes a panic)
+		for looping := true; looping; {
+			select {
+			case <-cg.closer:
+				log.Info(fmt.Sprintf("Closing kafka consumer controller of topic %q group %q", cg.topic, cg.group), nil)
+				<-cg.closed
+				looping = false
 			case err := <-cg.consumer.Errors():
+				log.Trace("controller---err msg rx", nil)
 				log.Error(err, nil)
 				cg.Errors() <- err
 			case <-time.After(tick):
+				log.Trace("controller---tick", nil)
 				if hasBalanced {
 					cg.consumer.CommitOffsets()
 				}
 			case n, more := <-cg.consumer.Notifications():
+				log.Trace("controller---note", log.Data{"n": n, "more": more})
 				if more {
 					hasBalanced = true
-					log.Trace("Rebalancing group", log.Data{"topic": cg.topic, "group": cg.group, "partitions": n.Current[topic]})
+					log.Trace("Rebalancing group", log.Data{"topic": cg.topic, "group": cg.group, "partitions": n.Current[cg.topic]})
 				}
 			}
 		}
+		log.Info(fmt.Sprintf("Closed kafka consumer controller of topic %q group %q", cg.topic, cg.group), nil)
 	}()
-	return &cg, nil
+
+	return cg, nil
 }

--- a/kafka/consumer-group.go
+++ b/kafka/consumer-group.go
@@ -149,6 +149,8 @@ func newConsumer(brokers []string, topic string, group string, offset int64, syn
 	// listener goroutine - listen to consumer.Messages() and upstream them
 	// if this blocks while upstreaming a message, we can shutdown consumer via the following goroutine
 	go func() {
+		logData := log.Data{"topic": topic, "group": group}
+
 		log.Info("Started kafka consumer listener", logData)
 		defer close(cg.closed)
 		for looping := true; looping; {
@@ -177,6 +179,8 @@ func newConsumer(brokers []string, topic string, group string, offset int64, syn
 
 	// control goroutine - allows us to close consumer even if blocked while upstreaming a message (above)
 	go func() {
+		logData := log.Data{"topic": topic, "group": group}
+
 		hasBalanced := false // avoid CommitOffsets() being called before we have balanced (otherwise causes a panic)
 		for looping := true; looping; {
 			select {

--- a/kafka/global.go
+++ b/kafka/global.go
@@ -4,7 +4,10 @@ import (
 	"github.com/Shopify/sarama"
 )
 
-const OffsetNewest = sarama.OffsetNewest
+const (
+	OffsetNewest = sarama.OffsetNewest
+	OffsetOldest = sarama.OffsetOldest
+)
 
 func SetMaxMessageSize(maxSize int32) {
 	sarama.MaxRequestSize = maxSize

--- a/kafka/kafkatest/message.go
+++ b/kafka/kafkatest/message.go
@@ -10,6 +10,7 @@ var _ kafka.Message = (*Message)(nil)
 type Message struct {
 	data      []byte
 	committed bool
+	offset    int64
 }
 
 // NewMessage returns a new mock message containing the given data.
@@ -32,4 +33,9 @@ func (m *Message) Commit() {
 // Committed returns true if commit was called on this message.
 func (m *Message) Committed() bool {
 	return m.committed
+}
+
+// Offset returns the message offset
+func (m *Message) Offset() int64 {
+	return m.offset
 }

--- a/kafka/message.go
+++ b/kafka/message.go
@@ -13,6 +13,9 @@ type Message interface {
 
 	// Commit the message's offset.
 	Commit()
+
+	// Offset returns the message offset
+	Offset() int64
 }
 
 // SaramaMessage represents a Sarama specific Kafka message
@@ -24,6 +27,11 @@ type SaramaMessage struct {
 // GetData returns the message contents.
 func (M SaramaMessage) GetData() []byte {
 	return M.message.Value
+}
+
+// Offset returns the message offset
+func (M SaramaMessage) Offset() int64 {
+	return M.message.Offset
 }
 
 // Commit the message's offset.

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -47,7 +47,7 @@ func (producer *Producer) Close(ctx context.Context) (err error) {
 		return producer.producer.Close()
 
 	case <-ctx.Done():
-		log.Info(fmt.Sprintf("Shutdown context time exceeded, skipping graceful shutdown of consumer group"), nil)
+		log.Info("Shutdown context time exceeded, skipping graceful shutdown of consumer group", nil)
 		return errors.New("Shutdown context timed out")
 	}
 }

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/Shopify/sarama"
 )
@@ -40,9 +41,9 @@ func (producer *Producer) Close(ctx context.Context) (err error) {
 
 	select {
 	case <-producer.closed:
-		log.Info(fmt.Sprintf("Successfully closed kafka consumer group"), nil)
 		close(producer.errors)
 		close(producer.output)
+		log.Info(fmt.Sprintf("Successfully closed kafka producer"), nil)
 		return producer.producer.Close()
 
 	case <-ctx.Done():

--- a/vendor/github.com/kelseyhightower/envconfig/LICENSE
+++ b/vendor/github.com/kelseyhightower/envconfig/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2013 Kelsey Hightower
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/kelseyhightower/envconfig/MAINTAINERS
+++ b/vendor/github.com/kelseyhightower/envconfig/MAINTAINERS
@@ -1,0 +1,2 @@
+Kelsey Hightower kelsey.hightower@gmail.com github.com/kelseyhightower
+Travis Parker    travis.parker@gmail.com    github.com/teepark

--- a/vendor/github.com/kelseyhightower/envconfig/README.md
+++ b/vendor/github.com/kelseyhightower/envconfig/README.md
@@ -1,0 +1,188 @@
+# envconfig
+
+[![Build Status](https://travis-ci.org/kelseyhightower/envconfig.svg)](https://travis-ci.org/kelseyhightower/envconfig)
+
+```Go
+import "github.com/kelseyhightower/envconfig"
+```
+
+## Documentation
+
+See [godoc](http://godoc.org/github.com/kelseyhightower/envconfig)
+
+## Usage
+
+Set some environment variables:
+
+```Bash
+export MYAPP_DEBUG=false
+export MYAPP_PORT=8080
+export MYAPP_USER=Kelsey
+export MYAPP_RATE="0.5"
+export MYAPP_TIMEOUT="3m"
+export MYAPP_USERS="rob,ken,robert"
+export MYAPP_COLORCODES="red:1,green:2,blue:3"
+```
+
+Write some code:
+
+```Go
+package main
+
+import (
+    "fmt"
+    "log"
+    "time"
+
+    "github.com/kelseyhightower/envconfig"
+)
+
+type Specification struct {
+    Debug       bool
+    Port        int
+    User        string
+    Users       []string
+    Rate        float32
+    Timeout     time.Duration
+    ColorCodes  map[string]int
+}
+
+func main() {
+    var s Specification
+    err := envconfig.Process("myapp", &s)
+    if err != nil {
+        log.Fatal(err.Error())
+    }
+    format := "Debug: %v\nPort: %d\nUser: %s\nRate: %f\nTimeout: %s\n"
+    _, err = fmt.Printf(format, s.Debug, s.Port, s.User, s.Rate, s.Timeout)
+    if err != nil {
+        log.Fatal(err.Error())
+    }
+
+    fmt.Println("Users:")
+    for _, u := range s.Users {
+        fmt.Printf("  %s\n", u)
+    }
+
+    fmt.Println("Color codes:")
+    for k, v := range s.ColorCodes {
+        fmt.Printf("  %s: %d\n", k, v)
+    }
+}
+```
+
+Results:
+
+```Bash
+Debug: false
+Port: 8080
+User: Kelsey
+Rate: 0.500000
+Timeout: 3m0s
+Users:
+  rob
+  ken
+  robert
+Color codes:
+  red: 1
+  green: 2
+  blue: 3
+```
+
+## Struct Tag Support
+
+Envconfig supports the use of struct tags to specify alternate, default, and required
+environment variables.
+
+For example, consider the following struct:
+
+```Go
+type Specification struct {
+    ManualOverride1 string `envconfig:"manual_override_1"`
+    DefaultVar      string `default:"foobar"`
+    RequiredVar     string `required:"true"`
+    IgnoredVar      string `ignored:"true"`
+    AutoSplitVar    string `split_words:"true"`
+}
+```
+
+Envconfig has automatic support for CamelCased struct elements when the
+`split_words:"true"` tag is supplied. Without this tag, `AutoSplitVar` above
+would look for an environment variable called `MYAPP_AUTOSPLITVAR`. With the
+setting applied it will look for `MYAPP_AUTO_SPLIT_VAR`. Note that numbers
+will get globbed into the previous word. If the setting does not do the
+right thing, you may use a manual override.
+
+Envconfig will process value for `ManualOverride1` by populating it with the
+value for `MYAPP_MANUAL_OVERRIDE_1`. Without this struct tag, it would have
+instead looked up `MYAPP_MANUALOVERRIDE1`. With the `split_words:"true"` tag
+it would have looked up `MYAPP_MANUAL_OVERRIDE1`.
+
+```Bash
+export MYAPP_MANUAL_OVERRIDE_1="this will be the value"
+
+# export MYAPP_MANUALOVERRIDE1="and this will not"
+```
+
+If envconfig can't find an environment variable value for `MYAPP_DEFAULTVAR`,
+it will populate it with "foobar" as a default value.
+
+If envconfig can't find an environment variable value for `MYAPP_REQUIREDVAR`,
+it will return an error when asked to process the struct.
+
+If envconfig can't find an environment variable in the form `PREFIX_MYVAR`, and there
+is a struct tag defined, it will try to populate your variable with an environment
+variable that directly matches the envconfig tag in your struct definition:
+
+```shell
+export SERVICE_HOST=127.0.0.1
+export MYAPP_DEBUG=true
+```
+```Go
+type Specification struct {
+    ServiceHost string `envconfig:"SERVICE_HOST"`
+    Debug       bool
+}
+```
+
+Envconfig won't process a field with the "ignored" tag set to "true", even if a corresponding
+environment variable is set.
+
+## Supported Struct Field Types
+
+envconfig supports supports these struct field types:
+
+  * string
+  * int8, int16, int32, int64
+  * bool
+  * float32, float64
+  * slices of any supported type
+  * maps (keys and values of any supported type)
+  * [encoding.TextUnmarshaler](https://golang.org/pkg/encoding/#TextUnmarshaler)
+
+Embedded structs using these fields are also supported.
+
+## Custom Decoders
+
+Any field whose type (or pointer-to-type) implements `envconfig.Decoder` can
+control its own deserialization:
+
+```Bash
+export DNS_SERVER=8.8.8.8
+```
+
+```Go
+type IPDecoder net.IP
+
+func (ipd *IPDecoder) Decode(value string) error {
+    *ipd = IPDecoder(net.ParseIP(value))
+    return nil
+}
+
+type DNSConfig struct {
+    Address IPDecoder `envconfig:"DNS_SERVER"`
+}
+```
+
+Also, envconfig will use a `Set(string) error` method like from the
+[flag.Value](https://godoc.org/flag#Value) interface if implemented.

--- a/vendor/github.com/kelseyhightower/envconfig/doc.go
+++ b/vendor/github.com/kelseyhightower/envconfig/doc.go
@@ -1,0 +1,8 @@
+// Copyright (c) 2013 Kelsey Hightower. All rights reserved.
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file.
+
+// Package envconfig implements decoding of environment variables based on a user
+// defined specification. A typical use is using environment variables for
+// configuration settings.
+package envconfig

--- a/vendor/github.com/kelseyhightower/envconfig/env_os.go
+++ b/vendor/github.com/kelseyhightower/envconfig/env_os.go
@@ -1,0 +1,7 @@
+// +build appengine
+
+package envconfig
+
+import "os"
+
+var lookupEnv = os.LookupEnv

--- a/vendor/github.com/kelseyhightower/envconfig/env_syscall.go
+++ b/vendor/github.com/kelseyhightower/envconfig/env_syscall.go
@@ -1,0 +1,7 @@
+// +build !appengine
+
+package envconfig
+
+import "syscall"
+
+var lookupEnv = syscall.Getenv

--- a/vendor/github.com/kelseyhightower/envconfig/envconfig.go
+++ b/vendor/github.com/kelseyhightower/envconfig/envconfig.go
@@ -1,0 +1,326 @@
+// Copyright (c) 2013 Kelsey Hightower. All rights reserved.
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file.
+
+package envconfig
+
+import (
+	"encoding"
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ErrInvalidSpecification indicates that a specification is of the wrong type.
+var ErrInvalidSpecification = errors.New("specification must be a struct pointer")
+
+// A ParseError occurs when an environment variable cannot be converted to
+// the type required by a struct field during assignment.
+type ParseError struct {
+	KeyName   string
+	FieldName string
+	TypeName  string
+	Value     string
+	Err       error
+}
+
+// Decoder has the same semantics as Setter, but takes higher precedence.
+// It is provided for historical compatibility.
+type Decoder interface {
+	Decode(value string) error
+}
+
+// Setter is implemented by types can self-deserialize values.
+// Any type that implements flag.Value also implements Setter.
+type Setter interface {
+	Set(value string) error
+}
+
+func (e *ParseError) Error() string {
+	return fmt.Sprintf("envconfig.Process: assigning %[1]s to %[2]s: converting '%[3]s' to type %[4]s. details: %[5]s", e.KeyName, e.FieldName, e.Value, e.TypeName, e.Err)
+}
+
+// varInfo maintains information about the configuration variable
+type varInfo struct {
+	Name  string
+	Alt   string
+	Key   string
+	Field reflect.Value
+	Tags  reflect.StructTag
+}
+
+// GatherInfo gathers information about the specified struct
+func gatherInfo(prefix string, spec interface{}) ([]varInfo, error) {
+	expr := regexp.MustCompile("([^A-Z]+|[A-Z][^A-Z]+|[A-Z]+)")
+	s := reflect.ValueOf(spec)
+
+	if s.Kind() != reflect.Ptr {
+		return nil, ErrInvalidSpecification
+	}
+	s = s.Elem()
+	if s.Kind() != reflect.Struct {
+		return nil, ErrInvalidSpecification
+	}
+	typeOfSpec := s.Type()
+
+	// over allocate an info array, we will extend if needed later
+	infos := make([]varInfo, 0, s.NumField())
+	for i := 0; i < s.NumField(); i++ {
+		f := s.Field(i)
+		ftype := typeOfSpec.Field(i)
+		if !f.CanSet() || isTrue(ftype.Tag.Get("ignored")) {
+			continue
+		}
+
+		for f.Kind() == reflect.Ptr {
+			if f.IsNil() {
+				if f.Type().Elem().Kind() != reflect.Struct {
+					// nil pointer to a non-struct: leave it alone
+					break
+				}
+				// nil pointer to struct: create a zero instance
+				f.Set(reflect.New(f.Type().Elem()))
+			}
+			f = f.Elem()
+		}
+
+		// Capture information about the config variable
+		info := varInfo{
+			Name:  ftype.Name,
+			Field: f,
+			Tags:  ftype.Tag,
+			Alt:   strings.ToUpper(ftype.Tag.Get("envconfig")),
+		}
+
+		// Default to the field name as the env var name (will be upcased)
+		info.Key = info.Name
+
+		// Best effort to un-pick camel casing as separate words
+		if isTrue(ftype.Tag.Get("split_words")) {
+			words := expr.FindAllStringSubmatch(ftype.Name, -1)
+			if len(words) > 0 {
+				var name []string
+				for _, words := range words {
+					name = append(name, words[0])
+				}
+
+				info.Key = strings.Join(name, "_")
+			}
+		}
+		if info.Alt != "" {
+			info.Key = info.Alt
+		}
+		if prefix != "" {
+			info.Key = fmt.Sprintf("%s_%s", prefix, info.Key)
+		}
+		info.Key = strings.ToUpper(info.Key)
+		infos = append(infos, info)
+
+		if f.Kind() == reflect.Struct {
+			// honor Decode if present
+			if decoderFrom(f) == nil && setterFrom(f) == nil && textUnmarshaler(f) == nil {
+				innerPrefix := prefix
+				if !ftype.Anonymous {
+					innerPrefix = info.Key
+				}
+
+				embeddedPtr := f.Addr().Interface()
+				embeddedInfos, err := gatherInfo(innerPrefix, embeddedPtr)
+				if err != nil {
+					return nil, err
+				}
+				infos = append(infos[:len(infos)-1], embeddedInfos...)
+
+				continue
+			}
+		}
+	}
+	return infos, nil
+}
+
+// Process populates the specified struct based on environment variables
+func Process(prefix string, spec interface{}) error {
+	infos, err := gatherInfo(prefix, spec)
+
+	for _, info := range infos {
+
+		// `os.Getenv` cannot differentiate between an explicitly set empty value
+		// and an unset value. `os.LookupEnv` is preferred to `syscall.Getenv`,
+		// but it is only available in go1.5 or newer. We're using Go build tags
+		// here to use os.LookupEnv for >=go1.5
+		value, ok := lookupEnv(info.Key)
+		if !ok && info.Alt != "" {
+			value, ok = lookupEnv(info.Alt)
+		}
+
+		def := info.Tags.Get("default")
+		if def != "" && !ok {
+			value = def
+		}
+
+		req := info.Tags.Get("required")
+		if !ok && def == "" {
+			if isTrue(req) {
+				return fmt.Errorf("required key %s missing value", info.Key)
+			}
+			continue
+		}
+
+		err := processField(value, info.Field)
+		if err != nil {
+			return &ParseError{
+				KeyName:   info.Key,
+				FieldName: info.Name,
+				TypeName:  info.Field.Type().String(),
+				Value:     value,
+				Err:       err,
+			}
+		}
+	}
+
+	return err
+}
+
+// MustProcess is the same as Process but panics if an error occurs
+func MustProcess(prefix string, spec interface{}) {
+	if err := Process(prefix, spec); err != nil {
+		panic(err)
+	}
+}
+
+func processField(value string, field reflect.Value) error {
+	typ := field.Type()
+
+	decoder := decoderFrom(field)
+	if decoder != nil {
+		return decoder.Decode(value)
+	}
+	// look for Set method if Decode not defined
+	setter := setterFrom(field)
+	if setter != nil {
+		return setter.Set(value)
+	}
+
+	if t := textUnmarshaler(field); t != nil {
+		return t.UnmarshalText([]byte(value))
+	}
+
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+		if field.IsNil() {
+			field.Set(reflect.New(typ))
+		}
+		field = field.Elem()
+	}
+
+	switch typ.Kind() {
+	case reflect.String:
+		field.SetString(value)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		var (
+			val int64
+			err error
+		)
+		if field.Kind() == reflect.Int64 && typ.PkgPath() == "time" && typ.Name() == "Duration" {
+			var d time.Duration
+			d, err = time.ParseDuration(value)
+			val = int64(d)
+		} else {
+			val, err = strconv.ParseInt(value, 0, typ.Bits())
+		}
+		if err != nil {
+			return err
+		}
+
+		field.SetInt(val)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		val, err := strconv.ParseUint(value, 0, typ.Bits())
+		if err != nil {
+			return err
+		}
+		field.SetUint(val)
+	case reflect.Bool:
+		val, err := strconv.ParseBool(value)
+		if err != nil {
+			return err
+		}
+		field.SetBool(val)
+	case reflect.Float32, reflect.Float64:
+		val, err := strconv.ParseFloat(value, typ.Bits())
+		if err != nil {
+			return err
+		}
+		field.SetFloat(val)
+	case reflect.Slice:
+		vals := strings.Split(value, ",")
+		sl := reflect.MakeSlice(typ, len(vals), len(vals))
+		for i, val := range vals {
+			err := processField(val, sl.Index(i))
+			if err != nil {
+				return err
+			}
+		}
+		field.Set(sl)
+	case reflect.Map:
+		mp := reflect.MakeMap(typ)
+		if len(strings.TrimSpace(value)) != 0 {
+			pairs := strings.Split(value, ",")
+			for _, pair := range pairs {
+				kvpair := strings.Split(pair, ":")
+				if len(kvpair) != 2 {
+					return fmt.Errorf("invalid map item: %q", pair)
+				}
+				k := reflect.New(typ.Key()).Elem()
+				err := processField(kvpair[0], k)
+				if err != nil {
+					return err
+				}
+				v := reflect.New(typ.Elem()).Elem()
+				err = processField(kvpair[1], v)
+				if err != nil {
+					return err
+				}
+				mp.SetMapIndex(k, v)
+			}
+		}
+		field.Set(mp)
+	}
+
+	return nil
+}
+
+func interfaceFrom(field reflect.Value, fn func(interface{}, *bool)) {
+	// it may be impossible for a struct field to fail this check
+	if !field.CanInterface() {
+		return
+	}
+	var ok bool
+	fn(field.Interface(), &ok)
+	if !ok && field.CanAddr() {
+		fn(field.Addr().Interface(), &ok)
+	}
+}
+
+func decoderFrom(field reflect.Value) (d Decoder) {
+	interfaceFrom(field, func(v interface{}, ok *bool) { d, *ok = v.(Decoder) })
+	return d
+}
+
+func setterFrom(field reflect.Value) (s Setter) {
+	interfaceFrom(field, func(v interface{}, ok *bool) { s, *ok = v.(Setter) })
+	return s
+}
+
+func textUnmarshaler(field reflect.Value) (t encoding.TextUnmarshaler) {
+	interfaceFrom(field, func(v interface{}, ok *bool) { t, *ok = v.(encoding.TextUnmarshaler) })
+	return t
+}
+
+func isTrue(s string) bool {
+	b, _ := strconv.ParseBool(s)
+	return b
+}

--- a/vendor/github.com/kelseyhightower/envconfig/usage.go
+++ b/vendor/github.com/kelseyhightower/envconfig/usage.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2016 Kelsey Hightower and others. All rights reserved.
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file.
+
+package envconfig
+
+import (
+	"encoding"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"text/template"
+)
+
+const (
+	// DefaultListFormat constant to use to display usage in a list format
+	DefaultListFormat = `This application is configured via the environment. The following environment
+variables can be used:
+{{range .}}
+{{usage_key .}}
+  [description] {{usage_description .}}
+  [type]        {{usage_type .}}
+  [default]     {{usage_default .}}
+  [required]    {{usage_required .}}{{end}}
+`
+	// DefaultTableFormat constant to use to display usage in a tabular format
+	DefaultTableFormat = `This application is configured via the environment. The following environment
+variables can be used:
+
+KEY	TYPE	DEFAULT	REQUIRED	DESCRIPTION
+{{range .}}{{usage_key .}}	{{usage_type .}}	{{usage_default .}}	{{usage_required .}}	{{usage_description .}}
+{{end}}`
+)
+
+var (
+	decoderType     = reflect.TypeOf((*Decoder)(nil)).Elem()
+	setterType      = reflect.TypeOf((*Setter)(nil)).Elem()
+	unmarshalerType = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
+)
+
+func implementsInterface(t reflect.Type) bool {
+	return t.Implements(decoderType) ||
+		reflect.PtrTo(t).Implements(decoderType) ||
+		t.Implements(setterType) ||
+		reflect.PtrTo(t).Implements(setterType) ||
+		t.Implements(unmarshalerType) ||
+		reflect.PtrTo(t).Implements(unmarshalerType)
+}
+
+// toTypeDescription converts Go types into a human readable description
+func toTypeDescription(t reflect.Type) string {
+	switch t.Kind() {
+	case reflect.Array, reflect.Slice:
+		return fmt.Sprintf("Comma-separated list of %s", toTypeDescription(t.Elem()))
+	case reflect.Map:
+		return fmt.Sprintf(
+			"Comma-separated list of %s:%s pairs",
+			toTypeDescription(t.Key()),
+			toTypeDescription(t.Elem()),
+		)
+	case reflect.Ptr:
+		return toTypeDescription(t.Elem())
+	case reflect.Struct:
+		if implementsInterface(t) && t.Name() != "" {
+			return t.Name()
+		}
+		return ""
+	case reflect.String:
+		name := t.Name()
+		if name != "" && name != "string" {
+			return name
+		}
+		return "String"
+	case reflect.Bool:
+		name := t.Name()
+		if name != "" && name != "bool" {
+			return name
+		}
+		return "True or False"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		name := t.Name()
+		if name != "" && !strings.HasPrefix(name, "int") {
+			return name
+		}
+		return "Integer"
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		name := t.Name()
+		if name != "" && !strings.HasPrefix(name, "uint") {
+			return name
+		}
+		return "Unsigned Integer"
+	case reflect.Float32, reflect.Float64:
+		name := t.Name()
+		if name != "" && !strings.HasPrefix(name, "float") {
+			return name
+		}
+		return "Float"
+	}
+	return fmt.Sprintf("%+v", t)
+}
+
+// Usage writes usage information to stderr using the default header and table format
+func Usage(prefix string, spec interface{}) error {
+	// The default is to output the usage information as a table
+	// Create tabwriter instance to support table output
+	tabs := tabwriter.NewWriter(os.Stdout, 1, 0, 4, ' ', 0)
+
+	err := Usagef(prefix, spec, tabs, DefaultTableFormat)
+	tabs.Flush()
+	return err
+}
+
+// Usagef writes usage information to the specified io.Writer using the specifed template specification
+func Usagef(prefix string, spec interface{}, out io.Writer, format string) error {
+
+	// Specify the default usage template functions
+	functions := template.FuncMap{
+		"usage_key":         func(v varInfo) string { return v.Key },
+		"usage_description": func(v varInfo) string { return v.Tags.Get("desc") },
+		"usage_type":        func(v varInfo) string { return toTypeDescription(v.Field.Type()) },
+		"usage_default":     func(v varInfo) string { return v.Tags.Get("default") },
+		"usage_required": func(v varInfo) (string, error) {
+			req := v.Tags.Get("required")
+			if req != "" {
+				reqB, err := strconv.ParseBool(req)
+				if err != nil {
+					return "", err
+				}
+				if reqB {
+					req = "true"
+				}
+			}
+			return req, nil
+		},
+	}
+
+	tmpl, err := template.New("envconfig").Funcs(functions).Parse(format)
+	if err != nil {
+		return err
+	}
+
+	return Usaget(prefix, spec, out, tmpl)
+}
+
+// Usaget writes usage information to the specified io.Writer using the specified template
+func Usaget(prefix string, spec interface{}, out io.Writer, tmpl *template.Template) error {
+	// gather first
+	infos, err := gatherInfo(prefix, spec)
+	if err != nil {
+		return err
+	}
+
+	return tmpl.Execute(out, infos)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -123,6 +123,12 @@
 			"revisionTime": "2016-09-10T10:38:22Z"
 		},
 		{
+			"checksumSHA1": "Jrjxy16tD9mUgr/jbhXwbHVeSa0=",
+			"path": "github.com/kelseyhightower/envconfig",
+			"revision": "462fda1f11d8cad3660e52737b8beefd27acfb3f",
+			"revisionTime": "2017-09-18T16:15:10Z"
+		},
+		{
 			"checksumSHA1": "hBgLmZ/4mCxmnH88mqFKBkpJFUY=",
 			"path": "github.com/mgutz/ansi",
 			"revision": "c286dcecd19ff979eeb73ea444e479b903f2cfcb",


### PR DESCRIPTION
Update to the kafka consumer and producer to handle a graceful shutdown. A new method to stop listening to kafka consumer group before calling close method on it. This allows an application to stop listening to new messages and yet handle any in flight messages before calling close function once committed back to the consumer group.

Updated example of how to use the new methods in a graceful shutdown process.