### PR TITLE
Feature/request query logging

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### What
+
+Describe what you have changed and why.
+
+### How to review
+
+Describe the steps required to test the changes.
+
+### Who can review
+
+Describe who worked on the changes, so that other people can review.

--- a/log/log.go
+++ b/log/log.go
@@ -48,14 +48,18 @@ func Handler(h http.Handler) http.Handler {
 		e := time.Now()
 		d := e.Sub(s)
 
-		Event("request", Context(req), Data{
+		data := Data{
 			"start":    s,
 			"end":      e,
 			"duration": d,
 			"status":   rc.statusCode,
 			"method":   req.Method,
 			"path":     req.URL.Path,
-		})
+		}
+		if len(req.URL.RawQuery) > 0 {
+			data["query"] = req.URL.Query()
+		}
+		Event("request", Context(req), data)
 	})
 }
 


### PR DESCRIPTION
### What

Log query string parameters as part of HTTP request logging

(Also added the github PR template)

### How to review

* Use the HTTP log handler in a service
* Check that `query` value _is not_ included if no query string is set
* Check that `query` value _is_ included if a query string is set

### Who can review

Anyone except @ian-kent