### PR TITLE
Add authentication wrapper function and readme

### DIFF
--- a/identity/README.md
+++ b/identity/README.md
@@ -1,0 +1,45 @@
+Identity middleware
+===================
+
+Middleware componenet that authenticates requests against zebedee.
+
+The identity and permissions returned from the identity endpoint are added to the request context.
+
+### Getting started
+
+Initialise the identity middleware and add it into the HTTP handler chain using alice:
+
+```
+    router := mux.NewRouter()
+    alice := alice.New(identity.Handler(true)).Then(router)
+    httpServer := server.New(config.BindAddr, alice)
+```
+
+Wrap authenticated endpoints using the `identity.Check(handler)` function to check that a request identity exists.
+
+```
+    router.Path("/jobs").Methods("POST").HandlerFunc(identity.Check(api.addJob))
+```
+
+Add required headers to outbound requests to other services
+
+```
+    req.Header.Add("Authorization", api.AuthToken)
+    req.Header.Add("User-Identity", ctx.Value("User-Identity").(string))
+```
+
+### Testing
+
+If you need to use the middleware component in unit tests you can call the constructor function that allows injection of the HTTP client
+
+```
+httpClient := &identitytest.HttpClientMock{
+    DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
+        return &http.Response{
+            StatusCode: http.StatusOK,
+        }, nil
+    },
+}
+
+identityHandler := identity.HandlerForHttpClient(doAuth, httpClient)
+```

--- a/identity/authentication.go
+++ b/identity/authentication.go
@@ -11,14 +11,19 @@ import (
 func Check(handle func(http.ResponseWriter, *http.Request)) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
+		log.DebugR(r, "checking for an identity in request context", nil)
+
 		callerIdentity := r.Context().Value(callerIdentityKey)
+		logData := log.Data{ "caller_identity": callerIdentity }
 
 		// just checking if an identity exists until permissions are being provided.
 		if callerIdentity == nil || callerIdentity == ""{
 			http.Error(w, "requested resource not found", http.StatusNotFound)
-			log.Error(errors.New("client missing auth token in header"), nil)
+			log.ErrorR(r, errors.New("no identity was found in the context of this request"), logData)
 			return
 		}
+
+		log.DebugR(r, "identity found in request context, calling downstream handler", logData)
 
 		// The request has been authenticated, now run the clients request
 		handle(w, r)

--- a/identity/authentication.go
+++ b/identity/authentication.go
@@ -1,0 +1,26 @@
+package identity
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/ONSdigital/go-ns/log"
+)
+
+// Check wraps a HTTP handler. If authentication fails an error code is returned else the HTTP handler is called
+func Check(handle func(http.ResponseWriter, *http.Request)) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		callerIdentity := r.Context().Value(callerIdentityKey)
+
+		// just checking if an identity exists until permissions are being provided.
+		if callerIdentity == nil || callerIdentity == ""{
+			http.Error(w, "requested resource not found", http.StatusNotFound)
+			log.Error(errors.New("client missing auth token in header"), nil)
+			return
+		}
+
+		// The request has been authenticated, now run the clients request
+		handle(w, r)
+	})
+}

--- a/identity/authentication.go
+++ b/identity/authentication.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/ONSdigital/go-ns/log"
 	"context"
+	"github.com/ONSdigital/go-ns/log"
 )
 
 // Check wraps a HTTP handler. If authentication fails an error code is returned else the HTTP handler is called
@@ -41,15 +41,27 @@ func IsPresent(ctx context.Context) bool {
 }
 
 // Caller gets the caller identity from the context
-func Caller(ctx context.Context) (string) {
+func Caller(ctx context.Context) string {
 
 	callerIdentity, _ := ctx.Value(callerIdentityKey).(string)
 	return callerIdentity
 }
 
 // User gets the user identity from the context
-func User(ctx context.Context) (string) {
+func User(ctx context.Context) string {
 
 	userIdentity, _ := ctx.Value(userIdentityKey).(string)
 	return userIdentity
+}
+
+// SetUser sets the given user ID on the given request
+func SetUser(user string, r *http.Request) {
+
+	r.Header.Add(userHeaderKey, user)
+}
+
+// SetServiceToken sets the given service token on the given request
+func SetServiceToken(serviceToken string, r *http.Request) {
+
+	r.Header.Add(authHeaderKey, serviceToken)
 }

--- a/identity/authentication.go
+++ b/identity/authentication.go
@@ -47,6 +47,12 @@ func Caller(ctx context.Context) string {
 	return callerIdentity
 }
 
+// SetCaller sets the caller identity on the context
+func SetCaller(ctx context.Context, caller string) context.Context {
+
+	return context.WithValue(ctx, callerIdentityKey, caller)
+}
+
 // User gets the user identity from the context
 func User(ctx context.Context) string {
 
@@ -54,14 +60,20 @@ func User(ctx context.Context) string {
 	return userIdentity
 }
 
-// SetUser sets the given user ID on the given request
-func SetUser(user string, r *http.Request) {
+// SetUser sets the user identity on the context
+func SetUser(ctx context.Context, user string) context.Context {
+
+	return context.WithValue(ctx, userIdentityKey, user)
+}
+
+// AddUserHeader sets the given user ID on the given request
+func AddUserHeader(r *http.Request, user string) {
 
 	r.Header.Add(userHeaderKey, user)
 }
 
-// SetServiceToken sets the given service token on the given request
-func SetServiceToken(serviceToken string, r *http.Request) {
+// AddServiceTokenHeader sets the given service token on the given request
+func AddServiceTokenHeader(r *http.Request, serviceToken string) {
 
 	r.Header.Add(authHeaderKey, serviceToken)
 }

--- a/identity/authentication.go
+++ b/identity/authentication.go
@@ -15,10 +15,10 @@ func Check(handle func(http.ResponseWriter, *http.Request)) http.HandlerFunc {
 		log.DebugR(r, "checking for an identity in request context", nil)
 
 		callerIdentity := r.Context().Value(callerIdentityKey)
-		logData := log.Data{ "caller_identity": callerIdentity }
+		logData := log.Data{"caller_identity": callerIdentity}
 
 		// just checking if an identity exists until permissions are being provided.
-		if !IsPresent(r.Context()){
+		if !IsPresent(r.Context()) {
 			http.Error(w, "requested resource not found", http.StatusNotFound)
 			log.ErrorR(r, errors.New("no identity was found in the context of this request"), logData)
 			return
@@ -32,10 +32,24 @@ func Check(handle func(http.ResponseWriter, *http.Request)) http.HandlerFunc {
 }
 
 // IsPresent determines if an identity is present on the given context.
-func IsPresent(context context.Context) bool {
+func IsPresent(ctx context.Context) bool {
 
-	callerIdentity := context.Value(callerIdentityKey)
+	callerIdentity := ctx.Value(callerIdentityKey)
 	isPresent := callerIdentity != nil && callerIdentity != ""
 
 	return isPresent
+}
+
+// Caller gets the caller identity from the context
+func Caller(ctx context.Context) (string) {
+
+	callerIdentity, _ := ctx.Value(callerIdentityKey).(string)
+	return callerIdentity
+}
+
+// User gets the user identity from the context
+func User(ctx context.Context) (string) {
+
+	userIdentity, _ := ctx.Value(userIdentityKey).(string)
+	return userIdentity
 }

--- a/identity/authentication.go
+++ b/identity/authentication.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/ONSdigital/go-ns/log"
+	"context"
 )
 
 // Check wraps a HTTP handler. If authentication fails an error code is returned else the HTTP handler is called
@@ -17,7 +18,7 @@ func Check(handle func(http.ResponseWriter, *http.Request)) http.HandlerFunc {
 		logData := log.Data{ "caller_identity": callerIdentity }
 
 		// just checking if an identity exists until permissions are being provided.
-		if callerIdentity == nil || callerIdentity == ""{
+		if !IsPresent(r.Context()){
 			http.Error(w, "requested resource not found", http.StatusNotFound)
 			log.ErrorR(r, errors.New("no identity was found in the context of this request"), logData)
 			return
@@ -28,4 +29,13 @@ func Check(handle func(http.ResponseWriter, *http.Request)) http.HandlerFunc {
 		// The request has been authenticated, now run the clients request
 		handle(w, r)
 	})
+}
+
+// IsPresent determines if an identity is present on the given context.
+func IsPresent(context context.Context) bool {
+
+	callerIdentity := context.Value(callerIdentityKey)
+	isPresent := callerIdentity != nil && callerIdentity != ""
+
+	return isPresent
 }

--- a/identity/authentication_test.go
+++ b/identity/authentication_test.go
@@ -1,0 +1,89 @@
+package identity
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"context"
+)
+
+func TestHandler_nilIdentity(t *testing.T) {
+	Convey("Given a request with no identity provided in the request context", t, func() {
+
+		req, err := http.NewRequest("POST", "http://localhost:21800/jobs", nil)
+		So(err, ShouldBeNil)
+		responseRecorder := httptest.NewRecorder()
+
+		handlerCalled := false
+		httpHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			handlerCalled = true
+		})
+
+		Convey("When the authentication handler is called", func() {
+
+			Check(httpHandler)(responseRecorder, req)
+
+			Convey("Then a 404 response is returned", func() {
+				So(responseRecorder.Code, ShouldEqual, http.StatusNotFound)
+			})
+		})
+	})
+}
+
+func TestHandler_emptyIdentity(t *testing.T) {
+	Convey("Given a request with an empty identity provided in the request context", t, func() {
+
+		req, err := http.NewRequest("POST", "http://localhost:21800/jobs", nil)
+
+		ctx := context.WithValue(req.Context(), callerIdentityKey, "")
+		req = req.WithContext(ctx)
+
+		So(err, ShouldBeNil)
+		responseRecorder := httptest.NewRecorder()
+
+		handlerCalled := false
+		httpHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			handlerCalled = true
+		})
+
+		Convey("When the authentication handler is called", func() {
+
+			Check(httpHandler)(responseRecorder, req)
+
+			Convey("Then a 404 response is returned", func() {
+				So(responseRecorder.Code, ShouldEqual, http.StatusNotFound)
+			})
+		})
+	})
+}
+
+
+func TestHandler_identityProvided(t *testing.T) {
+
+	Convey("Given a request with an identity provided in the request context", t, func() {
+
+		req, err := http.NewRequest("POST", "http://localhost:21800/jobs", nil)
+
+		ctx := context.WithValue(req.Context(), callerIdentityKey, "user@ons.gov.uk")
+		req = req.WithContext(ctx)
+
+		So(err, ShouldBeNil)
+		responseRecorder := httptest.NewRecorder()
+
+		handlerCalled := false
+		httpHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			handlerCalled = true
+		})
+
+		Convey("When the authentication handler is called", func() {
+
+			Check(httpHandler)(responseRecorder, req)
+
+			Convey("Then a 404 response is returned", func() {
+				So(responseRecorder.Code, ShouldEqual, http.StatusOK)
+			})
+		})
+	})
+}

--- a/identity/authentication_test.go
+++ b/identity/authentication_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
 	"context"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestCheck_nilIdentity(t *testing.T) {
@@ -27,6 +27,10 @@ func TestCheck_nilIdentity(t *testing.T) {
 
 			Convey("Then a 404 response is returned", func() {
 				So(responseRecorder.Code, ShouldEqual, http.StatusNotFound)
+			})
+
+			Convey("Then the downstream HTTP handler is not called", func() {
+				So(handlerCalled, ShouldBeFalse)
 			})
 		})
 	})
@@ -55,10 +59,13 @@ func TestCheck_emptyIdentity(t *testing.T) {
 			Convey("Then a 404 response is returned", func() {
 				So(responseRecorder.Code, ShouldEqual, http.StatusNotFound)
 			})
+
+			Convey("Then the downstream HTTP handler is not called", func() {
+				So(handlerCalled, ShouldBeFalse)
+			})
 		})
 	})
 }
-
 
 func TestCheck_identityProvided(t *testing.T) {
 
@@ -83,6 +90,10 @@ func TestCheck_identityProvided(t *testing.T) {
 
 			Convey("Then the response is true", func() {
 				So(responseRecorder.Code, ShouldEqual, http.StatusOK)
+			})
+
+			Convey("Then the downstream HTTP handler is called", func() {
+				So(handlerCalled, ShouldBeTrue)
 			})
 		})
 	})
@@ -189,7 +200,6 @@ func TestUser_emptyUserIdentity(t *testing.T) {
 	})
 }
 
-
 func TestCaller(t *testing.T) {
 
 	Convey("Given a context with a caller identity", t, func() {
@@ -236,6 +246,42 @@ func TestCaller_emptyCallerIdentity(t *testing.T) {
 
 			Convey("Then the response is empty", func() {
 				So(caller, ShouldEqual, "")
+			})
+		})
+	})
+}
+
+func TestSetUser(t *testing.T) {
+
+	Convey("Given a request", t, func() {
+
+		r, _ := http.NewRequest("POST", "http://localhost:21800/jobs", nil)
+
+		Convey("When SetUser is called", func() {
+
+			user := "someone@ons.gov.uk"
+			SetUser(user, r)
+
+			Convey("Then the request has the user header set", func() {
+				So(r.Header.Get(userHeaderKey), ShouldEqual, user)
+			})
+		})
+	})
+}
+
+func TestSetServiceToken(t *testing.T) {
+
+	Convey("Given a request", t, func() {
+
+		r, _ := http.NewRequest("POST", "http://localhost:21800/jobs", nil)
+
+		Convey("When SetServiceToken is called", func() {
+
+			serviceToken := "123"
+			SetServiceToken(serviceToken, r)
+
+			Convey("Then the request has the service token header set", func() {
+				So(r.Header.Get(authHeaderKey), ShouldEqual, serviceToken)
 			})
 		})
 	})

--- a/identity/authentication_test.go
+++ b/identity/authentication_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 )
 
-func TestHandler_nilIdentity(t *testing.T) {
+func TestCheck_nilIdentity(t *testing.T) {
 	Convey("Given a request with no identity provided in the request context", t, func() {
 
 		req, err := http.NewRequest("POST", "http://localhost:21800/jobs", nil)
@@ -32,7 +32,7 @@ func TestHandler_nilIdentity(t *testing.T) {
 	})
 }
 
-func TestHandler_emptyIdentity(t *testing.T) {
+func TestCheck_emptyIdentity(t *testing.T) {
 	Convey("Given a request with an empty identity provided in the request context", t, func() {
 
 		req, err := http.NewRequest("POST", "http://localhost:21800/jobs", nil)
@@ -60,7 +60,7 @@ func TestHandler_emptyIdentity(t *testing.T) {
 }
 
 
-func TestHandler_identityProvided(t *testing.T) {
+func TestCheck_identityProvided(t *testing.T) {
 
 	Convey("Given a request with an identity provided in the request context", t, func() {
 
@@ -81,8 +81,58 @@ func TestHandler_identityProvided(t *testing.T) {
 
 			Check(httpHandler)(responseRecorder, req)
 
-			Convey("Then a 404 response is returned", func() {
+			Convey("Then the response is true", func() {
 				So(responseRecorder.Code, ShouldEqual, http.StatusOK)
+			})
+		})
+	})
+}
+
+func TestIsPresent_withIdentity(t *testing.T) {
+
+	Convey("Given a context with an identity", t, func() {
+
+		ctx := context.WithValue(context.Background(), callerIdentityKey, "user@ons.gov.uk")
+
+		Convey("When IsPresent is called with the context", func() {
+
+			identityIsPresent := IsPresent(ctx)
+
+			Convey("Then a 404 response is returned", func() {
+				So(identityIsPresent, ShouldBeTrue)
+			})
+		})
+	})
+}
+
+func TestIsPresent_withNoIdentity(t *testing.T) {
+
+	Convey("Given a context with no identity", t, func() {
+
+		ctx := context.Background()
+
+		Convey("When IsPresent is called with the context", func() {
+
+			identityIsPresent := IsPresent(ctx)
+
+			Convey("Then the response is false", func() {
+				So(identityIsPresent, ShouldBeFalse)
+			})
+		})
+	})
+}
+
+func TestIsPresent_withEmptyIdentity(t *testing.T) {
+	Convey("Given a context with an empty identity", t, func() {
+
+		ctx := context.WithValue(context.Background(), callerIdentityKey, "")
+
+		Convey("When IsPresent is called with the context", func() {
+
+			identityIsPresent := IsPresent(ctx)
+
+			Convey("Then the response is false", func() {
+				So(identityIsPresent, ShouldBeFalse)
 			})
 		})
 	})

--- a/identity/authentication_test.go
+++ b/identity/authentication_test.go
@@ -109,7 +109,7 @@ func TestIsPresent_withIdentity(t *testing.T) {
 
 			identityIsPresent := IsPresent(ctx)
 
-			Convey("Then a 404 response is returned", func() {
+			Convey("Then the response is true", func() {
 				So(identityIsPresent, ShouldBeTrue)
 			})
 		})

--- a/identity/authentication_test.go
+++ b/identity/authentication_test.go
@@ -149,6 +149,24 @@ func TestIsPresent_withEmptyIdentity(t *testing.T) {
 	})
 }
 
+func TestSetUser(t *testing.T) {
+
+	Convey("Given a context", t, func() {
+
+		ctx := context.Background()
+
+		Convey("When SetUser is called", func() {
+
+			user := "someone@ons.gov.uk"
+			ctx = SetUser(ctx, user)
+
+			Convey("Then the response had the caller identity", func() {
+				So(ctx.Value(userIdentityKey), ShouldEqual, user)
+			})
+		})
+	})
+}
+
 func TestUser(t *testing.T) {
 
 	Convey("Given a context with a user identity", t, func() {
@@ -217,6 +235,24 @@ func TestCaller(t *testing.T) {
 	})
 }
 
+func TestSetCaller(t *testing.T) {
+
+	Convey("Given a context", t, func() {
+
+		ctx := context.Background()
+
+		Convey("When SetCaller is called", func() {
+
+			caller := "dp-dataset-api"
+			ctx = SetCaller(ctx, caller)
+
+			Convey("Then the response had the caller identity", func() {
+				So(ctx.Value(callerIdentityKey), ShouldEqual, caller)
+			})
+		})
+	})
+}
+
 func TestCaller_noCallerIdentity(t *testing.T) {
 
 	Convey("Given a context with no caller identity", t, func() {
@@ -251,16 +287,16 @@ func TestCaller_emptyCallerIdentity(t *testing.T) {
 	})
 }
 
-func TestSetUser(t *testing.T) {
+func TestAddUserHeader(t *testing.T) {
 
 	Convey("Given a request", t, func() {
 
 		r, _ := http.NewRequest("POST", "http://localhost:21800/jobs", nil)
 
-		Convey("When SetUser is called", func() {
+		Convey("When AddUserHeader is called", func() {
 
 			user := "someone@ons.gov.uk"
-			SetUser(user, r)
+			AddUserHeader(r, user)
 
 			Convey("Then the request has the user header set", func() {
 				So(r.Header.Get(userHeaderKey), ShouldEqual, user)
@@ -269,16 +305,16 @@ func TestSetUser(t *testing.T) {
 	})
 }
 
-func TestSetServiceToken(t *testing.T) {
+func TestAddServiceTokenHeader(t *testing.T) {
 
 	Convey("Given a request", t, func() {
 
 		r, _ := http.NewRequest("POST", "http://localhost:21800/jobs", nil)
 
-		Convey("When SetServiceToken is called", func() {
+		Convey("When AddServiceTokenHeader is called", func() {
 
 			serviceToken := "123"
-			SetServiceToken(serviceToken, r)
+			AddServiceTokenHeader(r, serviceToken)
 
 			Convey("Then the request has the service token header set", func() {
 				So(r.Header.Get(authHeaderKey), ShouldEqual, serviceToken)

--- a/identity/authentication_test.go
+++ b/identity/authentication_test.go
@@ -137,3 +137,106 @@ func TestIsPresent_withEmptyIdentity(t *testing.T) {
 		})
 	})
 }
+
+func TestUser(t *testing.T) {
+
+	Convey("Given a context with a user identity", t, func() {
+
+		ctx := context.WithValue(context.Background(), userIdentityKey, "Frederico")
+
+		Convey("When User is called with the context", func() {
+
+			user := User(ctx)
+
+			Convey("Then the response had the user identity", func() {
+				So(user, ShouldEqual, "Frederico")
+			})
+		})
+	})
+}
+
+func TestUser_noUserIdentity(t *testing.T) {
+
+	Convey("Given a context with no user identity", t, func() {
+
+		ctx := context.Background()
+
+		Convey("When User is called with the context", func() {
+
+			user := User(ctx)
+
+			Convey("Then the response is empty", func() {
+				So(user, ShouldEqual, "")
+			})
+		})
+	})
+}
+
+func TestUser_emptyUserIdentity(t *testing.T) {
+
+	Convey("Given a context with an empty user identity", t, func() {
+
+		ctx := context.WithValue(context.Background(), userIdentityKey, "")
+
+		Convey("When User is called with the context", func() {
+
+			user := User(ctx)
+
+			Convey("Then the response is empty", func() {
+				So(user, ShouldEqual, "")
+			})
+		})
+	})
+}
+
+
+func TestCaller(t *testing.T) {
+
+	Convey("Given a context with a caller identity", t, func() {
+
+		ctx := context.WithValue(context.Background(), callerIdentityKey, "Frederico")
+
+		Convey("When Caller is called with the context", func() {
+
+			caller := Caller(ctx)
+
+			Convey("Then the response had the caller identity", func() {
+				So(caller, ShouldEqual, "Frederico")
+			})
+		})
+	})
+}
+
+func TestCaller_noCallerIdentity(t *testing.T) {
+
+	Convey("Given a context with no caller identity", t, func() {
+
+		ctx := context.Background()
+
+		Convey("When Caller is called with the context", func() {
+
+			caller := Caller(ctx)
+
+			Convey("Then the response is empty", func() {
+				So(caller, ShouldEqual, "")
+			})
+		})
+	})
+}
+
+func TestCaller_emptyCallerIdentity(t *testing.T) {
+
+	Convey("Given a context with an empty caller identity", t, func() {
+
+		ctx := context.WithValue(context.Background(), callerIdentityKey, "")
+
+		Convey("When Caller is called with the context", func() {
+
+			caller := Caller(ctx)
+
+			Convey("Then the response is empty", func() {
+				So(caller, ShouldEqual, "")
+			})
+		})
+	})
+}

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -2,8 +2,6 @@ package identity
 
 import (
 	"net/http"
-	"os"
-
 	"github.com/ONSdigital/go-ns/rchttp"
 
 	"context"
@@ -14,7 +12,6 @@ import (
 
 //go:generate moq -out identitytest/http_client.go -pkg identitytest . HttpClient
 
-var zebedeeURL = os.Getenv("ZEBEDEE_URL")
 const florenceHeaderKey = "X-Florence-Token"
 const authHeaderKey = "Authorization"
 const userIdentityKey = "User-Identity"
@@ -29,12 +26,12 @@ type identityResponse struct {
 }
 
 // Handler controls the authenticating of a request
-func Handler(doAuth bool) func(http.Handler) http.Handler {
-	return HandlerForHttpClient(doAuth, rchttp.DefaultClient)
+func Handler(doAuth bool, zebedeeUrl string) func(http.Handler) http.Handler {
+	return HandlerForHttpClient(doAuth, rchttp.DefaultClient, zebedeeUrl)
 }
 
 // HandlerForHttpClient allows a handler to be created that uses the given HTTP client
-func HandlerForHttpClient(doAuth bool, cli HttpClient) func(http.Handler) http.Handler {
+func HandlerForHttpClient(doAuth bool, cli HttpClient, zebedeeUrl string) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 
@@ -58,12 +55,7 @@ func HandlerForHttpClient(doAuth bool, cli HttpClient) func(http.Handler) http.H
 
 				if isUserReq || isServiceReq {
 
-					// set a default zebedee value if it isn't set
-					if len(zebedeeURL) == 0 {
-						zebedeeURL = "http://localhost:8082"
-					}
-
-					url := zebedeeURL + "/identity"
+					url := zebedeeUrl + "/identity"
 
 					logData["url"] = url
 					log.DebugR(req, "calling zebedee to authenticate", logData)

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -26,12 +26,12 @@ type identityResponse struct {
 }
 
 // Handler controls the authenticating of a request
-func Handler(doAuth bool, zebedeeUrl string) func(http.Handler) http.Handler {
-	return HandlerForHttpClient(doAuth, rchttp.DefaultClient, zebedeeUrl)
+func Handler(doAuth bool, zebedeeURL string) func(http.Handler) http.Handler {
+	return HandlerForHttpClient(doAuth, rchttp.DefaultClient, zebedeeURL)
 }
 
 // HandlerForHttpClient allows a handler to be created that uses the given HTTP client
-func HandlerForHttpClient(doAuth bool, cli HttpClient, zebedeeUrl string) func(http.Handler) http.Handler {
+func HandlerForHttpClient(doAuth bool, cli HttpClient, zebedeeURL string) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 
@@ -55,7 +55,7 @@ func HandlerForHttpClient(doAuth bool, cli HttpClient, zebedeeUrl string) func(h
 
 				if isUserReq || isServiceReq {
 
-					url := zebedeeUrl + "/identity"
+					url := zebedeeURL + "/identity"
 
 					logData["url"] = url
 					log.DebugR(req, "calling zebedee to authenticate", logData)

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -1,16 +1,16 @@
 package identity
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"github.com/ONSdigital/go-ns/identity/identitytest"
 	"github.com/pkg/errors"
 	. "github.com/smartystreets/goconvey/convey"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"bytes"
-	"io/ioutil"
-	"encoding/json"
 )
 
 const url = "/whatever"
@@ -18,8 +18,8 @@ const florenceToken = "123"
 const authToken = "345"
 const serviceIdentifier = "api1"
 const userIdentifier = "fred@ons.gov.uk"
-const zebedeeUrl = "http://localhost:8082"
-const expectedZebedeeUrl = "http://localhost:8082/identity"
+const zebedeeURL = "http://localhost:8082"
+const expectedZebedeeURL = "http://localhost:8082/identity"
 
 func TestHandler_NoAuth(t *testing.T) {
 
@@ -29,7 +29,7 @@ func TestHandler_NoAuth(t *testing.T) {
 		req := httptest.NewRequest("GET", url, nil)
 		responseRecorder := httptest.NewRecorder()
 
-		httpClient := &identitytest.HttpClientMock{
+		httpClient := &identitytest.HTTPClientMock{
 			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
 				return nil, nil
 			},
@@ -40,7 +40,7 @@ func TestHandler_NoAuth(t *testing.T) {
 			handlerCalled = true
 		})
 
-		identityHandler := HandlerForHttpClient(doAuth, httpClient, zebedeeUrl)(httpHandler)
+		identityHandler := HandlerForHTTPClient(doAuth, httpClient, zebedeeURL)(httpHandler)
 
 		Convey("When ServeHTTP is called", func() {
 
@@ -61,7 +61,7 @@ func TestHandler_NoHeaders(t *testing.T) {
 		req := httptest.NewRequest("GET", url, nil)
 		responseRecorder := httptest.NewRecorder()
 
-		httpClient := &identitytest.HttpClientMock{
+		httpClient := &identitytest.HTTPClientMock{
 			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
 				return nil, nil
 			},
@@ -72,7 +72,7 @@ func TestHandler_NoHeaders(t *testing.T) {
 			handlerCalled = true
 		})
 
-		identityHandler := HandlerForHttpClient(doAuth, httpClient, zebedeeUrl)(httpHandler)
+		identityHandler := HandlerForHTTPClient(doAuth, httpClient, zebedeeURL)(httpHandler)
 
 		Convey("When ServeHTTP is called", func() {
 
@@ -96,7 +96,7 @@ func TestHandler_IdentityServiceError(t *testing.T) {
 		}
 		responseRecorder := httptest.NewRecorder()
 
-		httpClient := &identitytest.HttpClientMock{
+		httpClient := &identitytest.HTTPClientMock{
 			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
 				return nil, errors.New("broken")
 			},
@@ -107,7 +107,7 @@ func TestHandler_IdentityServiceError(t *testing.T) {
 			handlerCalled = true
 		})
 
-		identityHandler := HandlerForHttpClient(doAuth, httpClient, zebedeeUrl)(httpHandler)
+		identityHandler := HandlerForHTTPClient(doAuth, httpClient, zebedeeURL)(httpHandler)
 
 		Convey("When ServeHTTP is called", func() {
 
@@ -115,7 +115,7 @@ func TestHandler_IdentityServiceError(t *testing.T) {
 
 			Convey("Then the identity service is called as expected", func() {
 				So(len(httpClient.DoCalls()), ShouldEqual, 1)
-				So(httpClient.DoCalls()[0].Req.URL.String(), ShouldEqual, expectedZebedeeUrl)
+				So(httpClient.DoCalls()[0].Req.URL.String(), ShouldEqual, expectedZebedeeURL)
 			})
 
 			Convey("Then the response code is set as expected", func() {
@@ -140,7 +140,7 @@ func TestHandler_IdentityServiceErrorResponseCode(t *testing.T) {
 		}
 		responseRecorder := httptest.NewRecorder()
 
-		httpClient := &identitytest.HttpClientMock{
+		httpClient := &identitytest.HTTPClientMock{
 			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusNotFound,
@@ -153,7 +153,7 @@ func TestHandler_IdentityServiceErrorResponseCode(t *testing.T) {
 			handlerCalled = true
 		})
 
-		identityHandler := HandlerForHttpClient(doAuth, httpClient, zebedeeUrl)(httpHandler)
+		identityHandler := HandlerForHTTPClient(doAuth, httpClient, zebedeeURL)(httpHandler)
 
 		Convey("When ServeHTTP is called", func() {
 
@@ -161,7 +161,7 @@ func TestHandler_IdentityServiceErrorResponseCode(t *testing.T) {
 
 			Convey("Then the identity service is called as expected", func() {
 				So(len(httpClient.DoCalls()), ShouldEqual, 1)
-				So(httpClient.DoCalls()[0].Req.URL.String(), ShouldEqual, expectedZebedeeUrl)
+				So(httpClient.DoCalls()[0].Req.URL.String(), ShouldEqual, expectedZebedeeURL)
 			})
 
 			Convey("Then the response code is the same as returned from the identity service", func() {
@@ -186,7 +186,7 @@ func TestHandler_florenceToken(t *testing.T) {
 		}
 		responseRecorder := httptest.NewRecorder()
 
-		httpClient := &identitytest.HttpClientMock{
+		httpClient := &identitytest.HTTPClientMock{
 			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
 
 				response := &identityResponse{
@@ -211,7 +211,7 @@ func TestHandler_florenceToken(t *testing.T) {
 			handlerCalled = true
 		})
 
-		identityHandler := HandlerForHttpClient(doAuth, httpClient, zebedeeUrl)(httpHandler)
+		identityHandler := HandlerForHTTPClient(doAuth, httpClient, zebedeeURL)(httpHandler)
 
 		Convey("When ServeHTTP is called", func() {
 
@@ -220,7 +220,7 @@ func TestHandler_florenceToken(t *testing.T) {
 			Convey("Then the identity service is called as expected", func() {
 				So(len(httpClient.DoCalls()), ShouldEqual, 1)
 				zebedeeReq := httpClient.DoCalls()[0].Req
-				So(zebedeeReq.URL.String(), ShouldEqual, expectedZebedeeUrl)
+				So(zebedeeReq.URL.String(), ShouldEqual, expectedZebedeeURL)
 				So(zebedeeReq.Header[florenceHeaderKey][0], ShouldEqual, florenceToken)
 			})
 
@@ -247,9 +247,8 @@ func TestHandler_InvalidIdentityResponse(t *testing.T) {
 		}
 		responseRecorder := httptest.NewRecorder()
 
-		httpClient := &identitytest.HttpClientMock{
+		httpClient := &identitytest.HTTPClientMock{
 			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
-
 
 				reader := bytes.NewBufferString("{ invalid JSON")
 				readCloser := ioutil.NopCloser(reader)
@@ -262,13 +261,11 @@ func TestHandler_InvalidIdentityResponse(t *testing.T) {
 		}
 
 		handlerCalled := false
-		var handlerReq *http.Request
 		httpHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			handlerReq = req
 			handlerCalled = true
 		})
 
-		identityHandler := HandlerForHttpClient(doAuth, httpClient, zebedeeUrl)(httpHandler)
+		identityHandler := HandlerForHTTPClient(doAuth, httpClient, zebedeeURL)(httpHandler)
 
 		Convey("When ServeHTTP is called", func() {
 
@@ -277,7 +274,7 @@ func TestHandler_InvalidIdentityResponse(t *testing.T) {
 			Convey("Then the identity service is called as expected", func() {
 				So(len(httpClient.DoCalls()), ShouldEqual, 1)
 				zebedeeReq := httpClient.DoCalls()[0].Req
-				So(zebedeeReq.URL.String(), ShouldEqual, expectedZebedeeUrl)
+				So(zebedeeReq.URL.String(), ShouldEqual, expectedZebedeeURL)
 				So(zebedeeReq.Header[florenceHeaderKey][0], ShouldEqual, florenceToken)
 			})
 
@@ -300,11 +297,11 @@ func TestHandler_authToken(t *testing.T) {
 		req := httptest.NewRequest("GET", url, nil)
 		req.Header = map[string][]string{
 			authHeaderKey: {authToken},
-			userIdentityKey : {userIdentifier},
+			userHeaderKey: {userIdentifier},
 		}
 		responseRecorder := httptest.NewRecorder()
 
-		httpClient := &identitytest.HttpClientMock{
+		httpClient := &identitytest.HTTPClientMock{
 			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
 
 				response := &identityResponse{
@@ -330,7 +327,7 @@ func TestHandler_authToken(t *testing.T) {
 			handlerCalled = true
 		})
 
-		identityHandler := HandlerForHttpClient(doAuth, httpClient, zebedeeUrl)(httpHandler)
+		identityHandler := HandlerForHTTPClient(doAuth, httpClient, zebedeeURL)(httpHandler)
 
 		Convey("When ServeHTTP is called", func() {
 
@@ -339,7 +336,7 @@ func TestHandler_authToken(t *testing.T) {
 			Convey("Then the identity service is called as expected", func() {
 				So(len(httpClient.DoCalls()), ShouldEqual, 1)
 				zebedeeReq := httpClient.DoCalls()[0].Req
-				So(zebedeeReq.URL.String(), ShouldEqual, expectedZebedeeUrl)
+				So(zebedeeReq.URL.String(), ShouldEqual, expectedZebedeeURL)
 				So(zebedeeReq.Header[authHeaderKey][0], ShouldEqual, authToken)
 
 			})
@@ -364,11 +361,11 @@ func TestHandler_bothTokens(t *testing.T) {
 		req := httptest.NewRequest("GET", url, nil)
 		req.Header = map[string][]string{
 			florenceHeaderKey: {florenceToken},
-			authHeaderKey: {authToken},
+			authHeaderKey:     {authToken},
 		}
 		responseRecorder := httptest.NewRecorder()
 
-		httpClient := &identitytest.HttpClientMock{
+		httpClient := &identitytest.HTTPClientMock{
 			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
 
 				response := &identityResponse{
@@ -393,7 +390,7 @@ func TestHandler_bothTokens(t *testing.T) {
 			handlerCalled = true
 		})
 
-		identityHandler := HandlerForHttpClient(doAuth, httpClient, zebedeeUrl)(httpHandler)
+		identityHandler := HandlerForHTTPClient(doAuth, httpClient, zebedeeURL)(httpHandler)
 
 		Convey("When ServeHTTP is called", func() {
 
@@ -402,7 +399,7 @@ func TestHandler_bothTokens(t *testing.T) {
 			Convey("Then the identity service is called as expected", func() {
 				So(len(httpClient.DoCalls()), ShouldEqual, 1)
 				zebedeeReq := httpClient.DoCalls()[0].Req
-				So(zebedeeReq.URL.String(), ShouldEqual, expectedZebedeeUrl)
+				So(zebedeeReq.URL.String(), ShouldEqual, expectedZebedeeURL)
 				So(zebedeeReq.Header[florenceHeaderKey][0], ShouldEqual, florenceToken)
 			})
 

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -13,12 +13,13 @@ import (
 	"encoding/json"
 )
 
-var url = "/whatever"
-var florenceToken = "123"
-var authToken = "345"
-var serviceIdentifier = "api1"
-var userIdentifier = "fred@ons.gov.uk"
-var expectedZebedeeUrl = "http://localhost:8082/identity"
+const url = "/whatever"
+const florenceToken = "123"
+const authToken = "345"
+const serviceIdentifier = "api1"
+const userIdentifier = "fred@ons.gov.uk"
+const zebedeeUrl = "http://localhost:8082"
+const expectedZebedeeUrl = "http://localhost:8082/identity"
 
 func TestHandler_NoAuth(t *testing.T) {
 
@@ -39,7 +40,7 @@ func TestHandler_NoAuth(t *testing.T) {
 			handlerCalled = true
 		})
 
-		identityHandler := HandlerForHttpClient(doAuth, httpClient)(httpHandler)
+		identityHandler := HandlerForHttpClient(doAuth, httpClient, zebedeeUrl)(httpHandler)
 
 		Convey("When ServeHTTP is called", func() {
 
@@ -71,7 +72,7 @@ func TestHandler_NoHeaders(t *testing.T) {
 			handlerCalled = true
 		})
 
-		identityHandler := HandlerForHttpClient(doAuth, httpClient)(httpHandler)
+		identityHandler := HandlerForHttpClient(doAuth, httpClient, zebedeeUrl)(httpHandler)
 
 		Convey("When ServeHTTP is called", func() {
 
@@ -106,7 +107,7 @@ func TestHandler_IdentityServiceError(t *testing.T) {
 			handlerCalled = true
 		})
 
-		identityHandler := HandlerForHttpClient(doAuth, httpClient)(httpHandler)
+		identityHandler := HandlerForHttpClient(doAuth, httpClient, zebedeeUrl)(httpHandler)
 
 		Convey("When ServeHTTP is called", func() {
 
@@ -152,7 +153,7 @@ func TestHandler_IdentityServiceErrorResponseCode(t *testing.T) {
 			handlerCalled = true
 		})
 
-		identityHandler := HandlerForHttpClient(doAuth, httpClient)(httpHandler)
+		identityHandler := HandlerForHttpClient(doAuth, httpClient, zebedeeUrl)(httpHandler)
 
 		Convey("When ServeHTTP is called", func() {
 
@@ -210,7 +211,7 @@ func TestHandler_florenceToken(t *testing.T) {
 			handlerCalled = true
 		})
 
-		identityHandler := HandlerForHttpClient(doAuth, httpClient)(httpHandler)
+		identityHandler := HandlerForHttpClient(doAuth, httpClient, zebedeeUrl)(httpHandler)
 
 		Convey("When ServeHTTP is called", func() {
 
@@ -267,7 +268,7 @@ func TestHandler_InvalidIdentityResponse(t *testing.T) {
 			handlerCalled = true
 		})
 
-		identityHandler := HandlerForHttpClient(doAuth, httpClient)(httpHandler)
+		identityHandler := HandlerForHttpClient(doAuth, httpClient, zebedeeUrl)(httpHandler)
 
 		Convey("When ServeHTTP is called", func() {
 
@@ -329,7 +330,7 @@ func TestHandler_authToken(t *testing.T) {
 			handlerCalled = true
 		})
 
-		identityHandler := HandlerForHttpClient(doAuth, httpClient)(httpHandler)
+		identityHandler := HandlerForHttpClient(doAuth, httpClient, zebedeeUrl)(httpHandler)
 
 		Convey("When ServeHTTP is called", func() {
 
@@ -392,7 +393,7 @@ func TestHandler_bothTokens(t *testing.T) {
 			handlerCalled = true
 		})
 
-		identityHandler := HandlerForHttpClient(doAuth, httpClient)(httpHandler)
+		identityHandler := HandlerForHttpClient(doAuth, httpClient, zebedeeUrl)(httpHandler)
 
 		Convey("When ServeHTTP is called", func() {
 

--- a/identity/identitytest/http_client.go
+++ b/identity/identitytest/http_client.go
@@ -10,25 +10,25 @@ import (
 )
 
 var (
-	lockHttpClientMockDo sync.RWMutex
+	lockHTTPClientMockDo sync.RWMutex
 )
 
-// HttpClientMock is a mock implementation of HttpClient.
+// HTTPClientMock is a mock implementation of HTTPClient.
 //
-//     func TestSomethingThatUsesHttpClient(t *testing.T) {
+//     func TestSomethingThatUsesHTTPClient(t *testing.T) {
 //
-//         // make and configure a mocked HttpClient
-//         mockedHttpClient := &HttpClientMock{
+//         // make and configure a mocked HTTPClient
+//         mockedHTTPClient := &HTTPClientMock{
 //             DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
 // 	               panic("TODO: mock out the Do method")
 //             },
 //         }
 //
-//         // TODO: use mockedHttpClient in code that requires HttpClient
+//         // TODO: use mockedHTTPClient in code that requires HTTPClient
 //         //       and then make assertions.
 //
 //     }
-type HttpClientMock struct {
+type HTTPClientMock struct {
 	// DoFunc mocks the Do method.
 	DoFunc func(ctx context.Context, req *http.Request) (*http.Response, error)
 
@@ -45,9 +45,9 @@ type HttpClientMock struct {
 }
 
 // Do calls DoFunc.
-func (mock *HttpClientMock) Do(ctx context.Context, req *http.Request) (*http.Response, error) {
+func (mock *HTTPClientMock) Do(ctx context.Context, req *http.Request) (*http.Response, error) {
 	if mock.DoFunc == nil {
-		panic("moq: HttpClientMock.DoFunc is nil but HttpClient.Do was just called")
+		panic("moq: HTTPClientMock.DoFunc is nil but HTTPClient.Do was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
@@ -56,16 +56,16 @@ func (mock *HttpClientMock) Do(ctx context.Context, req *http.Request) (*http.Re
 		Ctx: ctx,
 		Req: req,
 	}
-	lockHttpClientMockDo.Lock()
+	lockHTTPClientMockDo.Lock()
 	mock.calls.Do = append(mock.calls.Do, callInfo)
-	lockHttpClientMockDo.Unlock()
+	lockHTTPClientMockDo.Unlock()
 	return mock.DoFunc(ctx, req)
 }
 
 // DoCalls gets all the calls that were made to Do.
 // Check the length with:
-//     len(mockedHttpClient.DoCalls())
-func (mock *HttpClientMock) DoCalls() []struct {
+//     len(mockedHTTPClient.DoCalls())
+func (mock *HTTPClientMock) DoCalls() []struct {
 	Ctx context.Context
 	Req *http.Request
 } {
@@ -73,8 +73,8 @@ func (mock *HttpClientMock) DoCalls() []struct {
 		Ctx context.Context
 		Req *http.Request
 	}
-	lockHttpClientMockDo.RLock()
+	lockHTTPClientMockDo.RLock()
 	calls = mock.calls.Do
-	lockHttpClientMockDo.RUnlock()
+	lockHTTPClientMockDo.RUnlock()
 	return calls
 }


### PR DESCRIPTION
### What

All existing API's are using the same function to wrap endpoints with an auth check. I have updated the function to work with identities stored in request context and added it to go-ns for reuse.

Added a readme to document the usage of the middleware and wrapper function.

### How to review

Review changes

### Who can review

Anyone
