### PR TITLE
use time based seed for random number generation

### DIFF
--- a/handlers/requestID/handler.go
+++ b/handlers/requestID/handler.go
@@ -3,7 +3,10 @@ package requestID
 import (
 	"math/rand"
 	"net/http"
+	"time"
 )
+
+var requestIDRandom = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 // Handler is a wrapper which adds an X-Request-Id header if one does not yet exist
 func Handler(size int) func(http.Handler) http.Handler {
@@ -16,7 +19,7 @@ func Handler(size int) func(http.Handler) http.Handler {
 			if len(requestID) == 0 {
 				b := make([]rune, size)
 				for i := range b {
-					b[i] = letters[rand.Intn(len(letters))]
+					b[i] = letters[requestIDRandom.Intn(len(letters))]
 				}
 				req.Header.Set("X-Request-Id", string(b))
 			}


### PR DESCRIPTION
### What

Uses a time based seed for random number generation in the requestID handler, which prevents request IDs reusing the same sequence when a service is restarted.

### How to review

* On a service which hasn't been updated yet:
   * Start the service
   * Make a request - remember the request ID
   * Restart the service
   * Make another request - the request ID should match the previous one
* Update a service to use the latest requestID handler
* Repeat the test above, but this time the request IDs should be different

### Who can review

Anyone except @ian-kent