### PR TITLE
added audit test helper to reduce replication

### DIFF
--- a/audit/README.md
+++ b/audit/README.md
@@ -44,5 +44,8 @@ if err := auditor.Record(ctx, "my_action", audit.Successful, auditParams); err !
     // handle error
 } 
 ```
-`Auditor.Record()` will return an error if there was a problem to auditing the event - in such cases the auditor will 
-log the error for you.
+`Auditor.Record()` will automatically extract `requestID`/`correlationID`, `User-Identity` & `Caller-Identity` from the
+ supplied context (if they exist) and add them to the audit event and log parameters.
+ 
+If `Auditor.Record()` fails to record the event it will log the error (including `requestID`/`correlationID`, 
+`User-Identity` & `Caller-Identity` if they are available) before returning.

--- a/audit/README.md
+++ b/audit/README.md
@@ -1,0 +1,48 @@
+## Auditing
+
+### Creating an auditor
+
+To create a new auditor simply provide a Kafka producer (see go-ns/kafka) for the topic you wish to send your audit 
+events to and the name of the service auditing the even. 
+```go
+auditor = audit.New(auditProducer, "dp-dataset-api")
+```
+
+You can also create a nop auditor which satisfies the `Auditor` interface but does nothing when called.
+
+```go
+auditor = &audit.NopAuditor{}
+```
+
+### Recording events
+To record an event simply call `Auditor.Record()` passing in the appropriate arguments for the event you wish to record.
+The following example is a typical use case for recording an audit event.
+```go
+// audit params is map holding additional useful information for the event
+auditParams := common.Params{"key":"value"}
+
+// audit that an action has been attempted
+if err := auditor.Record(ctx, "my_action", audit.Attempted, auditParams); err != nil {
+    // handle error
+}
+
+// attempt do carry out the action
+err := func() error {
+    // business logic...
+}()
+
+if err != nil {
+    // attempted action unsuccessful - record unsuccessful event
+    if err := auditor.Record(ctx, "my_action", audit.Unsuccessful, auditParams); err != nil {
+        // handle error
+    } 
+    // handle error
+}
+
+// action completed successfully - record success event
+if err := auditor.Record(ctx, "my_action", audit.Successful, auditParams); err != nil {
+    // handle error
+} 
+```
+`Auditor.Record()` will return an error if there was a problem to auditing the event - in such cases the auditor will 
+log the error for you.

--- a/audit/audit_mock/README.md
+++ b/audit/audit_mock/README.md
@@ -1,0 +1,22 @@
+### Testing auditing
+
+The `audit_mocks` package provides useful methods for verifying calls to `audit.Record()` reducing the amount of 
+duplication to setup and verify calls to an auditor in unit tests.
+
+### Getting started
+Create an auditor mock that returns no error.
+```go
+auditor := audit_mock.New()
+```
+Create an auditor mock that returns an error when `Record()` is called with particular action and result values
+```go
+auditor := audit_mock.NewErroring("some task", "the outcome")
+```
+Assert `auditor.Record()` is called the expected number of times and the `action`, `result` and `auditParam` values in
+ each call are as expected.
+```go
+auditor.AssertRecordCalls(
+    audit_mock.ExpectedParams{"my_action", audit.Attempted, common.Params{"key":"value"},
+    audit_mock.ExpectedParams{instance.GetInstancesAction, audit.Successful, nil},
+)
+```

--- a/audit/audit_mock/README.md
+++ b/audit/audit_mock/README.md
@@ -1,7 +1,7 @@
 ### Testing auditing
 
 The `audit_mocks` package provides useful methods for verifying calls to `audit.Record()` reducing the amount of 
-duplication to setup and verify calls to an auditor in unit tests.
+code duplication to setup a mock auditor and verify its invocations during a test case.
 
 ### Getting started
 Create an auditor mock that returns no error.

--- a/audit/audit_mock/helper.go
+++ b/audit/audit_mock/helper.go
@@ -36,7 +36,7 @@ func New() *MockAuditor {
 	}
 }
 
-//NewErroring creates new instance of MockAuditor that which return ErrAudit if the supplied audit action and result
+//NewErroring creates new instance of MockAuditor that will return ErrAudit if the supplied audit action and result
 // match the specified errir trigger values.
 func NewErroring(a string, r string) *MockAuditor {
 	return &MockAuditor{

--- a/audit/audit_mock/helper.go
+++ b/audit/audit_mock/helper.go
@@ -1,0 +1,71 @@
+package audit_mock
+
+import (
+	"context"
+	"errors"
+	"github.com/ONSdigital/go-ns/audit"
+	"github.com/ONSdigital/go-ns/common"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+//ErrAudit is the test error returned from a MockAuditor if the audit action & result match error trigger criteria
+var ErrAudit = errors.New("auditing error")
+
+//ExpectedParams is a struct encapsulating the method parameters to audit.Record
+type ExpectedParams struct {
+	Action string
+	Result string
+	Params common.Params
+}
+
+//MockAuditor is wrapper around the generated mock implementation of audit.AuditorService which can be configured
+// to return an error when specified audit action / result values are passed into the Record method, also provides
+//convenience test methods for asserting calls & params made to the mock.
+type MockAuditor struct {
+	*audit.AuditorServiceMock
+}
+
+//New creates new instance of MockAuditor that does not return any errors
+func New() *MockAuditor {
+	return &MockAuditor{
+		&audit.AuditorServiceMock{
+			RecordFunc: func(ctx context.Context, action string, result string, params common.Params) error {
+				return nil
+			},
+		},
+	}
+}
+
+//NewErroring creates new instance of MockAuditor that which return ErrAudit if the supplied audit action and result
+// match the specified errir trigger values.
+func NewErroring(a string, r string) *MockAuditor {
+	return &MockAuditor{
+		&audit.AuditorServiceMock{
+			RecordFunc: func(ctx context.Context, action string, result string, params common.Params) error {
+				if action == a && r == result {
+					audit.LogActionFailure(ctx, a, r, ErrAudit, audit.ToLogData(params))
+					return ErrAudit
+				}
+				return nil
+			},
+		},
+	}
+}
+
+//AssertRecordCalls is a convenience method which asserts the expected number of Record calls are made and
+// the parameters of each match the expected values.
+func (m *MockAuditor) AssertRecordCalls(expected ...ExpectedParams) {
+	actual := m.RecordCalls()
+
+	Convey("auditor.Record is called the expected number of times", func() {
+		So(len(actual), ShouldEqual, len(expected))
+	})
+
+	Convey("audit.Record is called with the expected parameters ", func() {
+		for i, call := range actual {
+			So(call.Action, ShouldEqual, expected[i].Action)
+			So(call.Result, ShouldEqual, expected[i].Result)
+			So(call.Params, ShouldResemble, expected[i].Params)
+		}
+	})
+}


### PR DESCRIPTION
### What

Created a `audit_mocks` package providing useful reusable methods required to test/assert auditing in other services. Reduce auditing footprint in test class and duplication of test setup/assertions etc.

### Examples
- Create an auditor mock 
```
auditor := audit_mock.New()
```
- Create an auditor mock that returns an error when `Record()` is called with particular action and result values
```
auditor := audit_mock.NewErroring("some task", "the outcome")
```
- Verify the expected number of calls and the parameter values provided
```
auditor.AssertRecordCalls(
    audit_mock.ExpectedParams{instance.GetInstancesAction, audit.Attempted, nil},
    audit_mock.ExpectedParams{instance.GetInstancesAction, audit.Successful, nil},
)
```

### How to review

Code review, try it ... the usual

### Who can review
Team B
