### PR TITLE
Extend rchttp for response status' of resource conflict (409)

### DIFF
--- a/rchttp/client.go
+++ b/rchttp/client.go
@@ -159,6 +159,10 @@ func (c *Client) Do(ctx context.Context, req *http.Request) (*http.Response, err
 		return c.backoff(doer, err, ctx, c.HTTPClient, req, errors.New("Bad server status"))
 	}
 
+	if c.ExponentialBackoff && resp.StatusCode == http.StatusConflict {
+		return c.backoff(doer, err, ctx, c.HTTPClient, req, errors.New("Conflict - request could not be completed due to a conflict with the current state of the target resource"))
+	}
+
 	return resp, err
 }
 

--- a/rchttp/client.go
+++ b/rchttp/client.go
@@ -155,12 +155,14 @@ func (c *Client) Do(ctx context.Context, req *http.Request) (*http.Response, err
 		return nil, err
 	}
 
-	if c.ExponentialBackoff && resp.StatusCode >= http.StatusInternalServerError {
-		return c.backoff(doer, err, ctx, c.HTTPClient, req, errors.New("Bad server status"))
-	}
+	if c.ExponentialBackoff {
+		if resp.StatusCode >= http.StatusInternalServerError {
+			return c.backoff(doer, err, ctx, c.HTTPClient, req, errors.New("Bad server status"))
+		}
 
-	if c.ExponentialBackoff && resp.StatusCode == http.StatusConflict {
-		return c.backoff(doer, err, ctx, c.HTTPClient, req, errors.New("Conflict - request could not be completed due to a conflict with the current state of the target resource"))
+		if resp.StatusCode == http.StatusConflict {
+			return c.backoff(doer, err, ctx, c.HTTPClient, req, errors.New("Conflict - request could not be completed due to a conflict with the current state of the target resource"))
+		}
 	}
 
 	return resp, err


### PR DESCRIPTION
### What

Extend rchttp to use exponential backoff if request receives a status conflict (409). This will allow for retriable requests to have another chance to update a resource after failing the first time due to being beaten to the resource by another update.

The above scenario occurs due to handlers retrieving data before doing several logical tasks (such as validation) and then updating that resource, this allows for another request to update the resource between the first request retrieving the data and then updating it. If this occurs a conflict status code (409) will be returned. We would want to retry this request as it is a fault from a race condition; the second attempt will either work or due to data changes fail via validation or other means (resource was deleted etc.)

### How to review

Check logic makes sense

### Who can review

Anyone
