### PR TITLE
Drain request body in identity middleware

### DIFF
--- a/identity/authentication.go
+++ b/identity/authentication.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ONSdigital/go-ns/audit"
 	"github.com/ONSdigital/go-ns/common"
 	"github.com/ONSdigital/go-ns/log"
+	"github.com/ONSdigital/go-ns/request"
 	"github.com/gorilla/mux"
 )
 
@@ -26,6 +27,7 @@ func Check(auditor Auditor, action string, handle func(http.ResponseWriter, *htt
 
 		if err := auditor.Record(ctx, action, audit.Attempted, auditParams); err != nil {
 			http.Error(w, "internal error", http.StatusInternalServerError)
+			request.DrainBody(r)
 			return
 		}
 
@@ -35,10 +37,12 @@ func Check(auditor Auditor, action string, handle func(http.ResponseWriter, *htt
 
 			if auditErr := auditor.Record(ctx, action, audit.Unsuccessful, auditParams); auditErr != nil {
 				http.Error(w, "internal error", http.StatusInternalServerError)
+				request.DrainBody(r)
 				return
 			}
-			http.Error(w, "unauthenticated request", http.StatusUnauthorized)
 
+			http.Error(w, "unauthenticated request", http.StatusUnauthorized)
+			request.DrainBody(r)
 			return
 		}
 

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -5,6 +5,7 @@ import (
 
 	clientsidentity "github.com/ONSdigital/go-ns/clients/identity"
 	"github.com/ONSdigital/go-ns/log"
+	"github.com/ONSdigital/go-ns/request"
 )
 
 // Handler controls the authenticating of a request
@@ -25,6 +26,7 @@ func HandlerForHTTPClient(cli clientsidentity.Clienter) func(http.Handler) http.
 			if err != nil {
 				log.ErrorR(req, err, logData)
 
+				request.DrainBody(req)
 				w.WriteHeader(statusCode)
 				return
 			}
@@ -32,6 +34,7 @@ func HandlerForHTTPClient(cli clientsidentity.Clienter) func(http.Handler) http.
 			if authFailure != nil {
 				log.ErrorR(req, authFailure, logData)
 
+				request.DrainBody(req)
 				w.WriteHeader(statusCode)
 				return
 			}

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ONSdigital/go-ns/common/commontest"
 	"github.com/pkg/errors"
 	. "github.com/smartystreets/goconvey/convey"
+	"io"
 )
 
 const (
@@ -30,7 +31,7 @@ func TestHandler_NoHeaders(t *testing.T) {
 
 	Convey("Given a http request with no headers", t, func() {
 
-		req := httptest.NewRequest("GET", url, nil)
+		req := httptest.NewRequest("GET", url, bytes.NewBufferString("some body content"))
 		responseRecorder := httptest.NewRecorder()
 
 		httpClient := &commontest.RCHTTPClienterMock{}
@@ -54,6 +55,11 @@ func TestHandler_NoHeaders(t *testing.T) {
 			Convey("Then the http response should have a 401 status", func() {
 				So(responseRecorder.Result().StatusCode, ShouldEqual, http.StatusUnauthorized)
 			})
+
+			Convey("Then the request body has been drained", func() {
+				_, err := req.Body.Read(make([]byte, 1))
+				So(err, ShouldEqual, io.EOF)
+			})
 		})
 	})
 }
@@ -62,7 +68,7 @@ func TestHandler_IdentityServiceError(t *testing.T) {
 
 	Convey("Given a request with a florence token, and mock client that returns an error", t, func() {
 
-		req := httptest.NewRequest("GET", url, nil)
+		req := httptest.NewRequest("GET", url, bytes.NewBufferString("some body content"))
 		req.Header = map[string][]string{
 			common.FlorenceHeaderKey: {florenceToken},
 		}
@@ -99,6 +105,11 @@ func TestHandler_IdentityServiceError(t *testing.T) {
 			Convey("Then the downstream HTTP handler is not called", func() {
 				So(handlerCalled, ShouldBeFalse)
 			})
+
+			Convey("Then the request body has been drained", func() {
+				_, err := req.Body.Read(make([]byte, 1))
+				So(err, ShouldEqual, io.EOF)
+			})
 		})
 	})
 }
@@ -107,7 +118,7 @@ func TestHandler_IdentityServiceErrorResponseCode(t *testing.T) {
 
 	Convey("Given a request with a florence token, and mock client that returns a non-200 response", t, func() {
 
-		req := httptest.NewRequest("GET", url, nil)
+		req := httptest.NewRequest("GET", url, bytes.NewBufferString("some body content"))
 		req.Header = map[string][]string{
 			common.FlorenceHeaderKey: {florenceToken},
 		}
@@ -146,6 +157,11 @@ func TestHandler_IdentityServiceErrorResponseCode(t *testing.T) {
 			Convey("Then the downstream HTTP handler is not called", func() {
 				So(handlerCalled, ShouldBeFalse)
 			})
+
+			Convey("Then the request body has been drained", func() {
+				_, err := req.Body.Read(make([]byte, 1))
+				So(err, ShouldEqual, io.EOF)
+			})
 		})
 	})
 }
@@ -154,7 +170,7 @@ func TestHandler_florenceToken(t *testing.T) {
 
 	Convey("Given a request with a florence token, and mock client that returns 200", t, func() {
 
-		req := httptest.NewRequest("GET", url, nil)
+		req := httptest.NewRequest("GET", url, bytes.NewBufferString("some body content"))
 		req.Header = map[string][]string{
 			common.FlorenceHeaderKey: {florenceToken},
 		}
@@ -213,7 +229,7 @@ func TestHandler_InvalidIdentityResponse(t *testing.T) {
 
 	Convey("Given a request with a florence token, and mock client that returns invalid response JSON", t, func() {
 
-		req := httptest.NewRequest("GET", url, nil)
+		req := httptest.NewRequest("GET", url, bytes.NewBufferString("some body content"))
 		req.Header = map[string][]string{
 			common.FlorenceHeaderKey: {florenceToken},
 		}
@@ -258,6 +274,11 @@ func TestHandler_InvalidIdentityResponse(t *testing.T) {
 			Convey("Then the downstream HTTP handler is not called", func() {
 				So(handlerCalled, ShouldBeFalse)
 			})
+
+			Convey("Then the request body has been drained", func() {
+				_, err := req.Body.Read(make([]byte, 1))
+				So(err, ShouldEqual, io.EOF)
+			})
 		})
 	})
 }
@@ -266,7 +287,7 @@ func TestHandler_authToken(t *testing.T) {
 
 	Convey("Given a request with an auth token, and mock client that returns 200", t, func() {
 
-		req := httptest.NewRequest("GET", url, nil)
+		req := httptest.NewRequest("GET", url, bytes.NewBufferString("some body content"))
 		req.Header = map[string][]string{
 			common.AuthHeaderKey: {upstreamAuthToken},
 			common.UserHeaderKey: {userIdentifier},
@@ -328,7 +349,7 @@ func TestHandler_bothTokens(t *testing.T) {
 
 	Convey("Given a request with both a florence token and service token", t, func() {
 
-		req := httptest.NewRequest("GET", url, nil)
+		req := httptest.NewRequest("GET", url, bytes.NewBufferString("some body content"))
 		req.Header = map[string][]string{
 			common.FlorenceHeaderKey:    {florenceToken},
 			common.DeprecatedAuthHeader: {upstreamAuthToken},

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -221,6 +221,11 @@ func TestHandler_florenceToken(t *testing.T) {
 				So(handlerReq.Context().Value(common.CallerIdentityKey), ShouldEqual, userIdentifier)
 				So(handlerReq.Context().Value(common.UserIdentityKey), ShouldEqual, userIdentifier)
 			})
+
+			Convey("Then the request body has not been drained", func() {
+				_, err := req.Body.Read(make([]byte, 1))
+				So(err, ShouldBeNil)
+			})
 		})
 	})
 }
@@ -341,6 +346,11 @@ func TestHandler_authToken(t *testing.T) {
 				So(common.Caller(handlerReq.Context()), ShouldEqual, serviceIdentifier)
 				So(common.User(handlerReq.Context()), ShouldEqual, userIdentifier)
 			})
+
+			Convey("Then the request body has not been drained", func() {
+				_, err := req.Body.Read(make([]byte, 1))
+				So(err, ShouldBeNil)
+			})
 		})
 	})
 }
@@ -400,6 +410,11 @@ func TestHandler_bothTokens(t *testing.T) {
 			Convey("Then the downstream HTTP handler request has the expected context values", func() {
 				So(handlerReq.Context().Value(common.UserIdentityKey), ShouldEqual, userIdentifier)
 				So(handlerReq.Context().Value(common.CallerIdentityKey), ShouldEqual, userIdentifier)
+			})
+
+			Convey("Then the request body has not been drained", func() {
+				_, err := req.Body.Read(make([]byte, 1))
+				So(err, ShouldBeNil)
 			})
 		})
 	})

--- a/request/request.go
+++ b/request/request.go
@@ -2,14 +2,19 @@ package request
 
 import (
 	"github.com/ONSdigital/go-ns/log"
+	"github.com/pkg/errors"
 	"io"
 	"io/ioutil"
 	"net/http"
-	"github.com/pkg/errors"
 )
 
 // DrainBody drains the body of the given of the given HTTP request.
 func DrainBody(r *http.Request) {
+
+	if r.Body == nil {
+		return
+	}
+
 	_, err := io.Copy(ioutil.Discard, r.Body)
 	if err != nil {
 		log.ErrorCtx(r.Context(), errors.Wrap(err, "error draining request body"), nil)

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -21,7 +21,28 @@ func TestDrainBody_WithRequestBody(t *testing.T) {
 
 			request.DrainBody(r)
 
-			Convey("The all bytes have been read from the body", func() {
+			Convey("Then all bytes have been read from the body", func() {
+				_, err = r.Body.Read(make([]byte, 1))
+				So(err, ShouldEqual, io.EOF)
+			})
+		})
+	})
+}
+
+func TestDrainBody_WithEmptyRequestBody(t *testing.T) {
+
+	Convey("Given a request with an empty body", t, func() {
+
+		body := bytes.NewBuffer(make([]byte, 0))
+
+		r, err := http.NewRequest("GET", "/some/url", body)
+		So(err, ShouldBeNil)
+
+		Convey("When the DrainBody function is called", func() {
+
+			request.DrainBody(r)
+
+			Convey("Then the expected io.EOF is returned when reading the body", func() {
 				_, err = r.Body.Read(make([]byte, 1))
 				So(err, ShouldEqual, io.EOF)
 			})

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -1,0 +1,44 @@
+package request_test
+
+import (
+	"bytes"
+	"github.com/ONSdigital/go-ns/request"
+	. "github.com/smartystreets/goconvey/convey"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestDrainBody_WithRequestBody(t *testing.T) {
+
+	Convey("Given a request with a body", t, func() {
+
+		body := bytes.NewBufferString("some body content")
+		r, err := http.NewRequest("GET", "/some/url", body)
+		So(err, ShouldBeNil)
+
+		Convey("When the DrainBody function is called", func() {
+
+			request.DrainBody(r)
+
+			Convey("The all bytes have been read from the body", func() {
+				_, err = r.Body.Read(make([]byte, 1))
+				So(err, ShouldEqual, io.EOF)
+			})
+		})
+	})
+}
+
+func TestDrainBody_WithoutRequestBody(t *testing.T) {
+
+	Convey("Given a request without a nil body", t, func() {
+
+		r, err := http.NewRequest("GET", "/some/url", nil)
+		So(err, ShouldBeNil)
+
+		Convey("When the DrainBody function is called, there is no panic", func() {
+
+			request.DrainBody(r)
+		})
+	})
+}


### PR DESCRIPTION
### What

For cases where some failure occurs in the identity middleware the
request body is not drained. This PR adds a call to drain the request
body when an error occurs and the downstream handler is not called.
 
I have updated the requests in existing tests to contain a request body (regardless of HTTP method) allowing us to assert that the body is drained.

### How to review

Review code / test

### Who can review

Anyone
