### PR TITLE
rchttp fix to retry even if response is http.StatusConflict (409)

### DIFF
--- a/rchttp/client.go
+++ b/rchttp/client.go
@@ -234,7 +234,7 @@ func (c *Client) backoff(f func(...interface{}) (*http.Response, error), retryEr
 			err = args[0].(context.Context).Err()
 			return
 		}
-		if err == nil && resp.StatusCode < http.StatusInternalServerError {
+		if err == nil && resp.StatusCode < http.StatusInternalServerError && resp.StatusCode != http.StatusConflict {
 			return
 		}
 	}


### PR DESCRIPTION
### What

keep retrying rchttp call on 409

### How to review

retest

### Who can review

Nathan