### PR TITLE
fixed broken legacy dataset download links

### DIFF
--- a/zebedee/zebedeeMapper/mapper.go
+++ b/zebedee/zebedeeMapper/mapper.go
@@ -63,6 +63,7 @@ func MapZebedeeDatasetLandingPageToFrontendModel(dlp data.DatasetLandingPage, bc
 	for i, d := range ds {
 		var dataset datasetLandingPageStatic.Dataset
 		for _, value := range d.Downloads {
+			dataset.URI = d.URI
 			dataset.Downloads = append(dataset.Downloads, datasetLandingPageStatic.Download{
 				URI:       value.File,
 				Extension: strings.TrimPrefix(filepath.Ext(value.File), "."),

--- a/zebedee/zebedeeMapper/mapper_test.go
+++ b/zebedee/zebedeeMapper/mapper_test.go
@@ -41,6 +41,13 @@ func TestUnitMapper(t *testing.T) {
 		So(sdlp.DatasetLandingPage.NextRelease, ShouldEqual, dlp.Description.NextRelease)
 
 		So(sdlp.Page.Breadcrumb[0].Title, ShouldEqual, bcs[0].Description.Title)
+
+		So(sdlp.DatasetLandingPage.Datasets, ShouldHaveLength, 1)
+		So(sdlp.DatasetLandingPage.Datasets[0].URI, ShouldEqual, "google.com")
+		So(sdlp.DatasetLandingPage.Datasets[0].Downloads, ShouldHaveLength, 1)
+		So(sdlp.DatasetLandingPage.Datasets[0].Downloads[0].URI, ShouldEqual, "helloworld.csv")
+		So(sdlp.DatasetLandingPage.Datasets[0].Downloads[0].Extension, ShouldEqual, "csv")
+		So(sdlp.DatasetLandingPage.Datasets[0].Downloads[0].Size, ShouldEqual, "452456")
 	})
 }
 


### PR DESCRIPTION
Fixed legacy dataset download links. URI was not being set when mapping to the frontend model. Added tests like a good boy.

