### PR TITLE
fixed file size defect in zebedee client

### DIFF
--- a/zebedee/client/client.go
+++ b/zebedee/client/client.go
@@ -175,23 +175,37 @@ func (c *ZebedeeClient) GetDataset(uri string) (data.Dataset, error) {
 		return d, err
 	}
 
+	downloads := make([]data.Download, 0)
+
 	for _, v := range d.Downloads {
 		fs, err := c.GetFileSize(uri + "/" + v.File)
 		if err != nil {
 			return d, err
 		}
 
-		v.Size = fs.Size
+		downloads = append(downloads, data.Download{
+			File: v.File,
+			Size: strconv.Itoa(fs.Size),
+		})
 	}
 
+	d.Downloads = downloads
+
+	supplementaryFiles := make([]data.SupplementaryFile, 0)
 	for _, v := range d.SupplementaryFiles {
 		fs, err := c.GetFileSize(uri + "/" + v.File)
 		if err != nil {
 			return d, err
 		}
 
-		v.Size = fs.Size
+		supplementaryFiles = append(supplementaryFiles, data.SupplementaryFile{
+			File:  v.File,
+			Title: v.Title,
+			Size:  strconv.Itoa(fs.Size),
+		})
 	}
+
+	d.SupplementaryFiles = supplementaryFiles
 
 	return d, nil
 }

--- a/zebedee/client/client_test.go
+++ b/zebedee/client/client_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -63,7 +64,7 @@ func TestUnitClient(t *testing.T) {
 	Convey("test getFileSize returns human readable filesize", t, func() {
 		fs, err := cli.GetFileSize("filesize")
 		So(err, ShouldBeNil)
-		So(fs.Size, ShouldEqual, "5242880")
+		So(fs.Size, ShouldEqual, 5242880)
 	})
 
 	Convey("test getPageTitle returns a correctly formatted page title", t, func() {
@@ -122,5 +123,16 @@ func parents(w http.ResponseWriter, req *http.Request) {
 }
 
 func filesize(w http.ResponseWriter, req *http.Request) {
-	w.Write([]byte(`{"fileSize":"5242880"}`))
+	zebedeeResponse := struct {
+		FileSize int `json:"fileSize"`
+	}{
+		FileSize: 5242880,
+	}
+
+	b, err := json.Marshal(zebedeeResponse)
+	if err != nil {
+		w.Write([]byte(err.Error()))
+		return
+	}
+	w.Write(b)
 }

--- a/zebedee/data/models.go
+++ b/zebedee/data/models.go
@@ -18,7 +18,7 @@ type Download struct {
 
 // FileSize represents a file size from zebedee
 type FileSize struct {
-	Size string `json:"fileSize"`
+	Size int `json:"fileSize"`
 }
 
 // PageTitle represents a page title from zebedee


### PR DESCRIPTION
### What

Fix file size defect for legacy dataset downloads. Zebedee file size response is an `int` whereas the CMD model is `string`.

### How to review
Run the CMD stack locally and go to a legacy dataset landing page and the download options should have the file sizes for each of the options.

For example: 
```
/economy/inflationandpriceindices/datasets/serviceproducerpriceindices
```
### Who can review

Anyone.
