### PR TITLE
fixed bug when setting the collection id cookie as a header

### DIFF
--- a/handlers/collectionID/handler.go
+++ b/handlers/collectionID/handler.go
@@ -2,8 +2,8 @@ package collectionID
 
 import (
 	"context"
-	"net/http"
 	"errors"
+	"net/http"
 
 	"github.com/ONSdigital/go-ns/common"
 	"github.com/ONSdigital/go-ns/log"
@@ -31,7 +31,7 @@ func CheckCookie(h http.Handler) http.Handler {
 
 		collectionIDCookie, err := req.Cookie(common.CollectionIDCookieKey)
 		if err == nil {
-			collectionID := collectionIDCookie.String()
+			collectionID := collectionIDCookie.Value
 			req = req.WithContext(context.WithValue(req.Context(), common.CollectionIDHeaderKey, collectionID))
 		} else {
 			if err != http.ErrNoCookie {


### PR DESCRIPTION
### What

Defect setting the collection ID header from a cookie. Was using `cookie.String()` which returns `key=value` instead of just `value` *e.g.* setting the request header as `collection=abc123` instead of `abc123`.
