### PR TITLE
added temp fix for user access token not being added to context and a…

### DIFF
--- a/handlers/accessToken/handler.go
+++ b/handlers/accessToken/handler.go
@@ -11,13 +11,10 @@ import (
 
 // CheckHeaderValueAndForwardWithRequestContext is a wrapper which adds a accessToken from the request header to context if one does not yet exist
 func CheckHeaderValueAndForwardWithRequestContext(h http.Handler) http.Handler {
-
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-
 		accessToken := req.Header.Get(common.AccessTokenHeaderKey)
-
 		if accessToken != "" {
-			req = req.WithContext(context.WithValue(req.Context(), common.AccessTokenHeaderKey, accessToken))
+			req = addUserAccessTokenToRequestContext(accessToken, req)
 		}
 
 		h.ServeHTTP(w, req)
@@ -26,19 +23,25 @@ func CheckHeaderValueAndForwardWithRequestContext(h http.Handler) http.Handler {
 
 // CheckCookieValueAndForwardWithRequestContext is a wrapper which adds a accessToken from the cookie to context if one does not yet exist
 func CheckCookieValueAndForwardWithRequestContext(h http.Handler) http.Handler {
-
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-
 		accessTokenCookie, err := req.Cookie(common.AccessTokenCookieKey)
-		if err == nil {
-			accessToken := accessTokenCookie.Value
-			req = req.WithContext(context.WithValue(req.Context(), common.AccessTokenHeaderKey, accessToken))
-		} else {
+		if err != nil {
 			if err != http.ErrNoCookie {
-				log.ErrorCtx(req.Context(), errors.New("unexpected error while extracting collection ID from cookie"), nil)
+				log.ErrorCtx(req.Context(), errors.New("unexpected error while extracting user Florence access token from cookie"), nil)
 			}
+		} else {
+			req = addUserAccessTokenToRequestContext(accessTokenCookie.Value, req)
 		}
 
 		h.ServeHTTP(w, req)
 	})
+}
+
+// addUserAccessTokenToRequestContext add the user florence access token to the request context. TODO TECHNICAL DEBT:
+//
+// There is inconsistency around which content key is used to store/retrieve the token. As a temp fix we are adding the
+// same value with both keys. To fix this properly we need to pick 1 context key and update all uses to use the same one.
+func addUserAccessTokenToRequestContext(userAccessToken string, req *http.Request) *http.Request {
+	req = req.WithContext(context.WithValue(req.Context(), common.AccessTokenHeaderKey, userAccessToken))
+	return req.WithContext(context.WithValue(req.Context(), common.FlorenceIdentityKey, userAccessToken))
 }

--- a/handlers/accessToken/handler_test.go
+++ b/handlers/accessToken/handler_test.go
@@ -1,0 +1,149 @@
+package accessToken
+
+import (
+	"context"
+	"github.com/ONSdigital/go-ns/common"
+	. "github.com/smartystreets/goconvey/convey"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const testToken = "666"
+
+type mockHandler struct {
+	invocations int
+	ctx         context.Context
+}
+
+func (m *mockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.invocations += 1
+	m.ctx = r.Context()
+}
+
+func TestCheckHeaderValueAndForwardWithRequestContext(t *testing.T) {
+	Convey("given the request with a florence access token header ", t, func() {
+		r := httptest.NewRequest("GET", "http://localhost:8080", nil)
+		r.Header.Set(common.AccessTokenHeaderKey, testToken)
+		w := httptest.NewRecorder()
+
+		mockHandler := &mockHandler{
+			invocations: 0,
+		}
+
+		target := CheckHeaderValueAndForwardWithRequestContext(mockHandler)
+
+		Convey("when the handler is called", func() {
+			target.ServeHTTP(w, r)
+
+			Convey("then the wrapped handle is called 1 time", func() {
+				So(mockHandler.invocations, ShouldEqual, 1)
+			})
+
+			Convey("and the request context contains a value for key X-Florence-Token", func() {
+				headerVal, ok := mockHandler.ctx.Value(common.AccessTokenHeaderKey).(string)
+				So(ok, ShouldBeTrue)
+				So(headerVal, ShouldEqual, testToken)
+			})
+
+			Convey("and the request context contains a value for key florence-id", func() {
+				xFlorenceToken, ok := mockHandler.ctx.Value(common.FlorenceIdentityKey).(string)
+				So(ok, ShouldBeTrue)
+				So(xFlorenceToken, ShouldEqual, testToken)
+			})
+		})
+	})
+
+	Convey("given the request does not contain a florence access token header ", t, func() {
+		r := httptest.NewRequest("GET", "http://localhost:8080", nil)
+		w := httptest.NewRecorder()
+
+		mockHandler := &mockHandler{
+			invocations: 0,
+		}
+
+		target := CheckHeaderValueAndForwardWithRequestContext(mockHandler)
+
+		Convey("when the handler is called", func() {
+			target.ServeHTTP(w, r)
+
+			Convey("then the wrapped handle is called 1 time", func() {
+				So(mockHandler.invocations, ShouldEqual, 1)
+			})
+
+			Convey("and the request context does not contain a value for key X-Florence-Token", func() {
+				headerVal := mockHandler.ctx.Value(common.AccessTokenHeaderKey)
+				So(headerVal, ShouldBeNil)
+			})
+
+			Convey("and the request context contains a value for key florence-id", func() {
+				xFlorenceToken := mockHandler.ctx.Value(common.FlorenceIdentityKey)
+				So(xFlorenceToken, ShouldBeNil)
+			})
+		})
+	})
+}
+
+func TestCheckCookieValueAndForwardWithRequestContext(t *testing.T) {
+	Convey("given the request contain a cookie for a florence access token header ", t, func() {
+		r := httptest.NewRequest("GET", "http://localhost:8080", nil)
+		r.AddCookie(&http.Cookie{Name: common.AccessTokenCookieKey, Value: testToken})
+
+		w := httptest.NewRecorder()
+
+		mockHandler := &mockHandler{
+			invocations: 0,
+		}
+
+		target := CheckCookieValueAndForwardWithRequestContext(mockHandler)
+
+		Convey("when the handler is called", func() {
+			target.ServeHTTP(w, r)
+
+			Convey("then the wrapped handle is called 1 time", func() {
+				So(mockHandler.invocations, ShouldEqual, 1)
+			})
+
+			Convey("and the request context contains a value for key X-Florence-Token", func() {
+				headerVal, ok := mockHandler.ctx.Value(common.AccessTokenHeaderKey).(string)
+				So(ok, ShouldBeTrue)
+				So(headerVal, ShouldEqual, testToken)
+			})
+
+			Convey("and the request context contains a value for key florence-id", func() {
+				xFlorenceToken, ok := mockHandler.ctx.Value(common.FlorenceIdentityKey).(string)
+				So(ok, ShouldBeTrue)
+				So(xFlorenceToken, ShouldEqual, testToken)
+			})
+		})
+	})
+
+	Convey("given the request does not contain a cookie for a florence access token header ", t, func() {
+		r := httptest.NewRequest("GET", "http://localhost:8080", nil)
+		w := httptest.NewRecorder()
+
+		mockHandler := &mockHandler{
+			invocations: 0,
+		}
+
+		target := CheckCookieValueAndForwardWithRequestContext(mockHandler)
+
+		Convey("when the handler is called", func() {
+			target.ServeHTTP(w, r)
+
+			Convey("then the wrapped handle is called 1 time", func() {
+				So(mockHandler.invocations, ShouldEqual, 1)
+			})
+
+			Convey("and the request context does not contain value for key X-Florence-Token", func() {
+				headerVal := mockHandler.ctx.Value(common.AccessTokenHeaderKey)
+				So(headerVal, ShouldBeNil)
+			})
+
+			Convey("and the request context does not contain value for key florence-id", func() {
+				xFlorenceToken := mockHandler.ctx.Value(common.FlorenceIdentityKey)
+				So(xFlorenceToken, ShouldBeNil)
+			})
+		})
+	})
+}


### PR DESCRIPTION
Fix for missing user Florence access token in request context.

**Tech Debt:**
There is inconsistency in which context key is used to store/retrieve the user access token in the request context. This fix updates the handlers to put the access token in the context user _both_ keys. Also added unit tests.

The correct fix is to choose one key and make everything consistent.
