### PR TITLE
Fix/remove duplicate access tokens in context

### DIFF
--- a/common/access_token.go
+++ b/common/access_token.go
@@ -1,6 +1,0 @@
-package common
-
-const (
-	AccessTokenHeaderKey = "X-Florence-Token"
-	AccessTokenCookieKey = "access_token"
-)

--- a/handlers/accessToken/handler.go
+++ b/handlers/accessToken/handler.go
@@ -37,10 +37,7 @@ func CheckCookieValueAndForwardWithRequestContext(h http.Handler) http.Handler {
 	})
 }
 
-// addUserAccessTokenToRequestContext add the user florence access token to the request context. TODO TECHNICAL DEBT:
-//
-// There is inconsistency around which content key is used to store/retrieve the token. As a temp fix we are adding the
-// same value with both keys. To fix this properly we need to pick 1 context key and update all uses to use the same one.
+// addUserAccessTokenToRequestContext add the user florence access token to the request context.
 func addUserAccessTokenToRequestContext(userAccessToken string, req *http.Request) *http.Request {
 	return req.WithContext(context.WithValue(req.Context(), common.FlorenceIdentityKey, userAccessToken))
 }

--- a/handlers/accessToken/handler.go
+++ b/handlers/accessToken/handler.go
@@ -12,7 +12,7 @@ import (
 // CheckHeaderValueAndForwardWithRequestContext is a wrapper which adds a accessToken from the request header to context if one does not yet exist
 func CheckHeaderValueAndForwardWithRequestContext(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		accessToken := req.Header.Get(common.AccessTokenHeaderKey)
+		accessToken := req.Header.Get(common.FlorenceHeaderKey)
 		if accessToken != "" {
 			req = addUserAccessTokenToRequestContext(accessToken, req)
 		}
@@ -24,7 +24,7 @@ func CheckHeaderValueAndForwardWithRequestContext(h http.Handler) http.Handler {
 // CheckCookieValueAndForwardWithRequestContext is a wrapper which adds a accessToken from the cookie to context if one does not yet exist
 func CheckCookieValueAndForwardWithRequestContext(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		accessTokenCookie, err := req.Cookie(common.AccessTokenCookieKey)
+		accessTokenCookie, err := req.Cookie(common.FlorenceCookieKey)
 		if err != nil {
 			if err != http.ErrNoCookie {
 				log.ErrorCtx(req.Context(), errors.New("unexpected error while extracting user Florence access token from cookie"), nil)
@@ -42,6 +42,5 @@ func CheckCookieValueAndForwardWithRequestContext(h http.Handler) http.Handler {
 // There is inconsistency around which content key is used to store/retrieve the token. As a temp fix we are adding the
 // same value with both keys. To fix this properly we need to pick 1 context key and update all uses to use the same one.
 func addUserAccessTokenToRequestContext(userAccessToken string, req *http.Request) *http.Request {
-	req = req.WithContext(context.WithValue(req.Context(), common.AccessTokenHeaderKey, userAccessToken))
 	return req.WithContext(context.WithValue(req.Context(), common.FlorenceIdentityKey, userAccessToken))
 }

--- a/handlers/accessToken/handler_test.go
+++ b/handlers/accessToken/handler_test.go
@@ -2,11 +2,12 @@ package accessToken
 
 import (
 	"context"
-	"github.com/ONSdigital/go-ns/common"
-	. "github.com/smartystreets/goconvey/convey"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/ONSdigital/go-ns/common"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 const testToken = "666"
@@ -24,7 +25,7 @@ func (m *mockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func TestCheckHeaderValueAndForwardWithRequestContext(t *testing.T) {
 	Convey("given the request with a florence access token header ", t, func() {
 		r := httptest.NewRequest("GET", "http://localhost:8080", nil)
-		r.Header.Set(common.AccessTokenHeaderKey, testToken)
+		r.Header.Set(common.FlorenceHeaderKey, testToken)
 		w := httptest.NewRecorder()
 
 		mockHandler := &mockHandler{
@@ -38,12 +39,6 @@ func TestCheckHeaderValueAndForwardWithRequestContext(t *testing.T) {
 
 			Convey("then the wrapped handle is called 1 time", func() {
 				So(mockHandler.invocations, ShouldEqual, 1)
-			})
-
-			Convey("and the request context contains a value for key X-Florence-Token", func() {
-				headerVal, ok := mockHandler.ctx.Value(common.AccessTokenHeaderKey).(string)
-				So(ok, ShouldBeTrue)
-				So(headerVal, ShouldEqual, testToken)
 			})
 
 			Convey("and the request context contains a value for key florence-id", func() {
@@ -71,11 +66,6 @@ func TestCheckHeaderValueAndForwardWithRequestContext(t *testing.T) {
 				So(mockHandler.invocations, ShouldEqual, 1)
 			})
 
-			Convey("and the request context does not contain a value for key X-Florence-Token", func() {
-				headerVal := mockHandler.ctx.Value(common.AccessTokenHeaderKey)
-				So(headerVal, ShouldBeNil)
-			})
-
 			Convey("and the request context contains a value for key florence-id", func() {
 				xFlorenceToken := mockHandler.ctx.Value(common.FlorenceIdentityKey)
 				So(xFlorenceToken, ShouldBeNil)
@@ -87,7 +77,7 @@ func TestCheckHeaderValueAndForwardWithRequestContext(t *testing.T) {
 func TestCheckCookieValueAndForwardWithRequestContext(t *testing.T) {
 	Convey("given the request contain a cookie for a florence access token header ", t, func() {
 		r := httptest.NewRequest("GET", "http://localhost:8080", nil)
-		r.AddCookie(&http.Cookie{Name: common.AccessTokenCookieKey, Value: testToken})
+		r.AddCookie(&http.Cookie{Name: common.FlorenceCookieKey, Value: testToken})
 
 		w := httptest.NewRecorder()
 
@@ -102,12 +92,6 @@ func TestCheckCookieValueAndForwardWithRequestContext(t *testing.T) {
 
 			Convey("then the wrapped handle is called 1 time", func() {
 				So(mockHandler.invocations, ShouldEqual, 1)
-			})
-
-			Convey("and the request context contains a value for key X-Florence-Token", func() {
-				headerVal, ok := mockHandler.ctx.Value(common.AccessTokenHeaderKey).(string)
-				So(ok, ShouldBeTrue)
-				So(headerVal, ShouldEqual, testToken)
 			})
 
 			Convey("and the request context contains a value for key florence-id", func() {
@@ -133,11 +117,6 @@ func TestCheckCookieValueAndForwardWithRequestContext(t *testing.T) {
 
 			Convey("then the wrapped handle is called 1 time", func() {
 				So(mockHandler.invocations, ShouldEqual, 1)
-			})
-
-			Convey("and the request context does not contain value for key X-Florence-Token", func() {
-				headerVal := mockHandler.ctx.Value(common.AccessTokenHeaderKey)
-				So(headerVal, ShouldBeNil)
 			})
 
 			Convey("and the request context does not contain value for key florence-id", func() {

--- a/zebedee/client/client.go
+++ b/zebedee/client/client.go
@@ -128,8 +128,8 @@ func (c *ZebedeeClient) get(ctx context.Context, path string) ([]byte, error) {
 		return nil, err
 	}
 
-	if ctx.Value(common.AccessTokenHeaderKey) != nil {
-		accessToken, ok := ctx.Value(common.AccessTokenHeaderKey).(string)
+	if ctx.Value(common.FlorenceIdentityKey) != nil {
+		accessToken, ok := ctx.Value(common.FlorenceIdentityKey).(string)
 		if !ok {
 			log.ErrorCtx(ctx, errors.New("error casting access token cookie to string"), nil)
 		}


### PR DESCRIPTION
### What

- Update accessToken handler package to use consistent (with already created) constants to prevent duplicate entries in context
- Update Zebedee client to use consistent constants
- Update tests to check for consistent constants and remove check for duplicate context entry

### Who can review

Anyone
