### PR TITLE
Switch Hierarchy api to use the newer RCHTTP client

### DIFF
--- a/clients/hierarchy/hierarchy.go
+++ b/clients/hierarchy/hierarchy.go
@@ -7,9 +7,9 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/ONSdigital/dp-rchttp"
 	"github.com/ONSdigital/go-ns/clients/clientlog"
 	"github.com/ONSdigital/go-ns/log"
-	"github.com/ONSdigital/go-ns/rhttp"
 )
 
 const service = "hierarchy-api"
@@ -40,21 +40,29 @@ var _ error = ErrInvalidHierarchyAPIResponse{}
 
 // Client is a hierarchy api client which can be used to make requests to the server
 type Client struct {
-	cli *rhttp.Client
+	cli rchttp.Clienter
 	url string
+}
+
+func closeResponseBody(ctx context.Context, resp *http.Response) {
+	if err := resp.Body.Close(); err != nil {
+		log.ErrorCtx(ctx, err, log.Data{"Message": "error closing http response body"})
+	}
 }
 
 // New creates a new instance of Client with a given filter api url
 func New(hierarchyAPIURL string) *Client {
 	return &Client{
-		cli: rhttp.DefaultClient,
+		cli: rchttp.NewClient(),
 		url: hierarchyAPIURL,
 	}
 }
 
 // Healthcheck calls the healthcheck endpoint on the api and alerts the caller of any errors
 func (c *Client) Healthcheck() (string, error) {
-	resp, err := c.cli.Get(c.url + "/healthcheck")
+	ctx := context.Background()
+
+	resp, err := c.cli.Get(ctx, c.url + "/healthcheck")
 	if err != nil {
 		return service, err
 	}
@@ -67,37 +75,45 @@ func (c *Client) Healthcheck() (string, error) {
 }
 
 // GetRoot returns the root hierarchy response from the hierarchy API
-func (c *Client) GetRoot(instanceID, name string) (m Model, err error) {
+func (c *Client) GetRoot(ctx context.Context, instanceID, name string) (m Model, err error) {
 	path := fmt.Sprintf("/hierarchies/%s/%s", instanceID, name)
 
-	clientlog.Do(context.Background(), "retrieving hierarchy", service, path, log.Data{
+	clientlog.Do(ctx, "retrieving hierarchy", service, path, log.Data{
 		"method":      "GET",
 		"instance_id": instanceID,
 		"dimension":   name,
 	})
 
-	return c.getHierarchy(path)
+	return c.getHierarchy(path, ctx)
 }
 
 // GetChild returns a child of a given hierarchy and code
-func (c *Client) GetChild(instanceID, name, code string) (m Model, err error) {
+func (c *Client) GetChild(ctx context.Context, instanceID, name, code string) (m Model, err error) {
 	path := fmt.Sprintf("/hierarchies/%s/%s/%s", instanceID, name, code)
 
-	clientlog.Do(context.Background(), "retrieving hierarchy", service, path, log.Data{
+	clientlog.Do(ctx, "retrieving hierarchy", service, path, log.Data{
 		"method":      "GET",
 		"instance_id": instanceID,
 		"dimension":   name,
 		"code":        code,
 	})
 
-	return c.getHierarchy(path)
+	return c.getHierarchy(path, ctx)
 }
 
-func (c *Client) getHierarchy(path string) (m Model, err error) {
-	resp, err := c.cli.Get(c.url + path)
+func (c *Client) getHierarchy(path string, ctx context.Context) (m Model, err error) {
+
+	req, err := http.NewRequest("GET", c.url + path, nil)
 	if err != nil {
 		return
 	}
+
+	resp, err := c.cli.Do(ctx, req)
+	if err != nil {
+		return
+	}
+
+	defer closeResponseBody(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		return m, &ErrInvalidHierarchyAPIResponse{http.StatusOK, resp.StatusCode, path}
@@ -107,7 +123,6 @@ func (c *Client) getHierarchy(path string) (m Model, err error) {
 	if err != nil {
 		return
 	}
-	defer resp.Body.Close()
 
 	err = json.Unmarshal(b, &m)
 	return

--- a/clients/hierarchy/hierarchy_test.go
+++ b/clients/hierarchy/hierarchy_test.go
@@ -1,0 +1,104 @@
+package hierarchy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ONSdigital/dp-rchttp"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+// client with no retries, no backoff
+var client = &rchttp.Client{HTTPClient: &http.Client{}}
+var ctx = context.Background()
+
+type MockedHTTPResponse struct {
+	StatusCode int
+	Body       string
+}
+
+func getMockHierarchyAPI(expectRequest http.Request, mockedHTTPResponse MockedHTTPResponse) *Client {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != expectRequest.Method {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("unexpected HTTP method used"))
+			return
+		}
+		w.WriteHeader(mockedHTTPResponse.StatusCode)
+		fmt.Fprintln(w, mockedHTTPResponse.Body)
+	}))
+	return New(ts.URL)
+}
+
+func TestClient_GetRoot(t *testing.T) {
+	instanceID := "foo"
+	name := "bar"
+	model := `{"label":"","has_data":true}`
+	Convey("When bad request is returned", t, func() {
+		mockedAPI := getMockHierarchyAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 400, Body: ""})
+		_, err := mockedAPI.GetRoot(ctx, instanceID, name)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("When server error is returned", t, func() {
+		mockedAPI := getMockHierarchyAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 500, Body: "qux"})
+		_, err := mockedAPI.GetRoot(ctx, instanceID, name)
+		So(err, ShouldNotBeNil)
+	})
+	Convey("When a filter-instance is returned", t, func() {
+		mockedAPI := getMockHierarchyAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 200, Body: model})
+		_, err := mockedAPI.GetRoot(ctx, instanceID, name)
+		So(err, ShouldBeNil)
+	})
+
+}
+
+func TestClient_GetChild(t *testing.T) {
+	instanceID := "foo"
+	name := "bar"
+	code := "baz"
+	model := `{"label":"","has_data":true}`
+	Convey("When bad request is returned", t, func() {
+		mockedAPI := getMockHierarchyAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 400, Body: ""})
+		_, err := mockedAPI.GetChild(ctx, instanceID, name, code)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("When server error is returned", t, func() {
+		mockedAPI := getMockHierarchyAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 500, Body: "qux"})
+		_, err := mockedAPI.GetChild(ctx, instanceID, name, code)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("When a filter-instance is returned", t, func() {
+		mockedAPI := getMockHierarchyAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 200, Body: model})
+		_, err := mockedAPI.GetChild(ctx, instanceID, name, code)
+		So(err, ShouldBeNil)
+	})
+}
+func TestClient_GetHierarchy(t *testing.T) {
+	path := "/hierarchies/foo/bar"
+	model := `{"label":"","has_data":true}`
+
+	Convey("When bad request is returned", t, func() {
+		mockedAPI := getMockHierarchyAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 400, Body: ""})
+		_, err := mockedAPI.getHierarchy(path, ctx)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("When server error is returned", t, func() {
+		mockedAPI := getMockHierarchyAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 500, Body: "qux"})
+		_, err := mockedAPI.getHierarchy(path, ctx)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("When a filter-instance is returned", t, func() {
+		mockedAPI := getMockHierarchyAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 200, Body: model})
+		_, err := mockedAPI.getHierarchy(path, ctx)
+		So(err, ShouldBeNil)
+	})
+
+}


### PR DESCRIPTION
### What

1. Hierarchy-api updated to use the new RCHTTP library instead of the go-ns RHTTP library. 
2. Tests added
3. Fix issues with defer not being called to close response body at the correct time and handling errors for the closing of the response body

### How to review

1. Checkout the branch
2. Run the tests
3. Ensure that the rchttp is used correctly and that errors are handled correctly

_Note: These tests are fairly minimal as they are not technically in scope for this task - ideally they should have been there already._

### Who can review

Anyone except me