### PR TITLE
updated identity middleware handler, added more unit tests and update…

### DIFF
--- a/identity/identity.go
+++ b/identity/identity.go
@@ -1,12 +1,13 @@
 package identity
 
 import (
+	"context"
 	"net/http"
 
-	clientsidentity "github.com/ONSdigital/go-ns/clients/identity"
-	"github.com/ONSdigital/go-ns/log"
-	"github.com/ONSdigital/go-ns/request"
+	clientsidentity "github.com/ONSdigital/dp-api-clients-go/identity"
 	"github.com/ONSdigital/go-ns/common"
+	"github.com/ONSdigital/go-ns/request"
+	"github.com/ONSdigital/log.go/log"
 )
 
 // Handler controls the authenticating of a request
@@ -19,44 +20,55 @@ func Handler(zebedeeURL string) func(http.Handler) http.Handler {
 func HandlerForHTTPClient(cli *clientsidentity.Client) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ctx := req.Context()
+			log.Event(ctx, "executing identity check middleware")
 
-			log.DebugR(req, "identity middleware called", nil)
+			florenceToken := getFlorenceTokenFromRequest(ctx, req)
+			serviceAuthToken := req.Header.Get(common.AuthHeaderKey)
 
-			florenceToken := req.Header.Get(common.FlorenceHeaderKey)
-			if len(florenceToken) < 1 {
-				c, err := req.Cookie(common.FlorenceCookieKey)
-				if err != nil {
-					log.DebugR(req, err.Error(), nil)
-				} else {
-					florenceToken = c.Value
-				}
-			}
-
-			authToken := req.Header.Get(common.AuthHeaderKey)
-
-			ctx, statusCode, authFailure, err := cli.CheckRequest(req, florenceToken, authToken)
+			ctx, statusCode, authFailure, err := cli.CheckRequest(req, florenceToken, serviceAuthToken)
 			logData := log.Data{"auth_status_code": statusCode}
-			if err != nil {
-				log.ErrorR(req, err, logData)
 
+			if err != nil {
+				log.Event(ctx, "identity client check request returned an error", log.Error(err), logData)
 				request.DrainBody(req)
 				w.WriteHeader(statusCode)
 				return
 			}
 
 			if authFailure != nil {
-				log.ErrorR(req, authFailure, logData)
-
+				log.Event(ctx, "identity client check request returned an auth error", log.Error(authFailure), logData)
 				request.DrainBody(req)
 				w.WriteHeader(statusCode)
 				return
 			}
 
+			log.Event(ctx, "identity client check request completed successfully invoking downstream http handler")
+
 			req = req.WithContext(ctx)
-
-			log.DebugR(req, "identity middleware finished, calling downstream handler", nil)
-
 			h.ServeHTTP(w, req)
 		})
 	}
+}
+
+func getFlorenceTokenFromRequest(ctx context.Context, req *http.Request) string {
+	var florenceToken string
+
+	florenceToken = req.Header.Get(common.FlorenceHeaderKey)
+	if len(florenceToken) >= 1 {
+		log.Event(ctx, "florence access token header found")
+		return florenceToken
+	}
+
+	log.Event(ctx, "florence access token header not found attempting to find access token cookie")
+	c, err := req.Cookie(common.FlorenceCookieKey)
+	if err != nil {
+		log.Event(ctx, "error getting florence access token cookie from request", log.Error(err))
+		return florenceToken
+	}
+
+	log.Event(ctx, "found request access token cookie")
+	florenceToken = c.Value
+
+	return florenceToken
 }

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -9,7 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	clientsidentity "github.com/ONSdigital/go-ns/clients/identity"
+	clientsidentity "github.com/ONSdigital/dp-api-clients-go/identity"
 	"github.com/ONSdigital/go-ns/common"
 	"github.com/ONSdigital/go-ns/common/commontest"
 	"github.com/pkg/errors"
@@ -417,5 +417,33 @@ func TestHandler_bothTokens(t *testing.T) {
 				So(err, ShouldBeNil)
 			})
 		})
+	})
+}
+
+func TestGetFlorenceTokenFromRequest(t *testing.T) {
+	expectedToken := "666"
+
+	Convey("should return florence token from request header", t, func() {
+		req := httptest.NewRequest("GET", "http://localhost:8080", nil)
+		req.Header.Set(common.FlorenceHeaderKey, expectedToken)
+
+		actual := getFlorenceTokenFromRequest(nil, req)
+
+		So(actual, ShouldEqual, expectedToken)
+	})
+
+	Convey("should return access token from request cookie", t, func() {
+		req := httptest.NewRequest("GET", "http://localhost:8080", nil)
+		req.AddCookie(&http.Cookie{Name: common.FlorenceCookieKey, Value: expectedToken})
+
+		actual := getFlorenceTokenFromRequest(nil, req)
+
+		So(actual, ShouldEqual, expectedToken)
+	})
+
+	Convey("should return empty token if no header or cookie is set", t, func() {
+		req := httptest.NewRequest("GET", "http://localhost:8080", nil)
+		actual := getFlorenceTokenFromRequest(nil, req)
+		So(actual, ShouldBeEmpty)
 	})
 }


### PR DESCRIPTION
Updated `identity` handler:
- Replaced `go-ns/clients/identity` with `dp-api-clients-go/identity`
- Replaced `go-ns/log` with `log.go/log`
- Renamed `authToken` var to `serviceAuthToken` for clarity and consistency with our naming convention.
- Extracted `getFlorenceTokenFromRequest` into separate func and added unit tests.