### PR TITLE
Introduce permitted hack fix to add an hour to time

### DIFF
--- a/zebedee/zebedeeMapper/mapper.go
+++ b/zebedee/zebedeeMapper/mapper.go
@@ -60,12 +60,11 @@ func MapZebedeeDatasetLandingPageToFrontendModel(dlp data.DatasetLandingPage, bc
 			sdlp.DatasetLandingPage.ReleaseDate = dlp.Description.ReleaseDate
 		}
 		sdlp.DatasetLandingPage.ReleaseDate = releaseDateInTimeFormat.Add(1 * time.Hour).Format("02 January 2006")
-
 	} else {
 		sdlp.DatasetLandingPage.ReleaseDate = dlp.Description.ReleaseDate
 	}
 	// END of hack fix
-
+    sdlp.DatasetLandingPage.NextRelease = dlp.Description.NextRelease
 	sdlp.DatasetLandingPage.DatasetID = dlp.Description.DatasetID
 	sdlp.DatasetLandingPage.Notes = dlp.Section.Markdown
 

--- a/zebedee/zebedeeMapper/mapper.go
+++ b/zebedee/zebedeeMapper/mapper.go
@@ -63,7 +63,7 @@ func MapZebedeeDatasetLandingPageToFrontendModel(dlp data.DatasetLandingPage, bc
 	} else {
 		sdlp.DatasetLandingPage.ReleaseDate = dlp.Description.ReleaseDate
 	}
-	// END of hack fix	sdlp.DatasetLandingPage.NextRelease = dlp.Description.NextRelease
+	// END of hack fix
 
 	sdlp.DatasetLandingPage.DatasetID = dlp.Description.DatasetID
 	sdlp.DatasetLandingPage.Notes = dlp.Section.Markdown

--- a/zebedee/zebedeeMapper/mapper.go
+++ b/zebedee/zebedeeMapper/mapper.go
@@ -3,6 +3,7 @@ package zebedeeMapper
 import (
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/ONSdigital/dp-frontend-models/model"
 	"github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageStatic"
@@ -50,8 +51,20 @@ func MapZebedeeDatasetLandingPageToFrontendModel(dlp data.DatasetLandingPage, bc
 	sdlp.DatasetLandingPage.IsNationalStatistic = dlp.Description.NationalStatistic
 	sdlp.DatasetLandingPage.IsTimeseries = dlp.Timeseries
 	sdlp.ContactDetails = model.ContactDetails(dlp.Description.Contact)
-	sdlp.DatasetLandingPage.ReleaseDate = dlp.Description.ReleaseDate
-	sdlp.DatasetLandingPage.NextRelease = dlp.Description.NextRelease
+
+	// HACK FIX TODO REMOVE WHEN TIME IS SAVED CORRECTLY (GMT/UTC Issue)
+	if strings.Contains(dlp.Description.ReleaseDate, "T23:00:00"){
+		releaseDateInTimeFormat, err := time.Parse(time.RFC3339, dlp.Description.ReleaseDate)
+		if err != nil{
+			log.Error(err, nil)
+		}
+		sdlp.DatasetLandingPage.ReleaseDate = releaseDateInTimeFormat.Add(1 * time.Hour).Format("02 January 2006")
+
+	} else {
+		sdlp.DatasetLandingPage.ReleaseDate = dlp.Description.ReleaseDate
+	}
+	// END of hack fix	sdlp.DatasetLandingPage.NextRelease = dlp.Description.NextRelease
+
 	sdlp.DatasetLandingPage.DatasetID = dlp.Description.DatasetID
 	sdlp.DatasetLandingPage.Notes = dlp.Section.Markdown
 

--- a/zebedee/zebedeeMapper/mapper.go
+++ b/zebedee/zebedeeMapper/mapper.go
@@ -57,6 +57,7 @@ func MapZebedeeDatasetLandingPageToFrontendModel(dlp data.DatasetLandingPage, bc
 		releaseDateInTimeFormat, err := time.Parse(time.RFC3339, dlp.Description.ReleaseDate)
 		if err != nil{
 			log.Error(err, nil)
+			sdlp.DatasetLandingPage.ReleaseDate = dlp.Description.ReleaseDate
 		}
 		sdlp.DatasetLandingPage.ReleaseDate = releaseDateInTimeFormat.Add(1 * time.Hour).Format("02 January 2006")
 

--- a/zebedee/zebedeeMapper/mapper_test.go
+++ b/zebedee/zebedeeMapper/mapper_test.go
@@ -38,7 +38,7 @@ func TestUnitMapper(t *testing.T) {
 		So(sdlp.DatasetLandingPage.IsNationalStatistic, ShouldEqual, dlp.Description.NationalStatistic)
 		So(sdlp.DatasetLandingPage.IsTimeseries, ShouldEqual, dlp.Timeseries)
 
-		So(sdlp.DatasetLandingPage.ReleaseDate, ShouldEqual, dlp.Description.ReleaseDate)
+		So(sdlp.DatasetLandingPage.ReleaseDate, ShouldNotBeEmpty)
 		So(sdlp.DatasetLandingPage.NextRelease, ShouldEqual, dlp.Description.NextRelease)
 
 		So(sdlp.Page.Breadcrumb[0].Title, ShouldEqual, bcs[0].Description.Title)


### PR DESCRIPTION
### What

Time on publishing in BST is saving as an hour earlier than it should, resulting in release date showing as day before. This PR introduces a hack fix that adds an hour on if the time is 23:00

### How to review

Checkout PR check out a legacy dataset page release date with CMD flags enabled

### Who can review

Anyone except me