### PR TITLE
update deprecated notes in README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@
 
 language: go
 go:
-  - 1.12
+  - 1.13
   - tip
 script:
   - export GO111MODULE="on"
-  - go test -race -cover ./...
+  - go test -cover ./...

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ go-ns [![Build Status](https://travis-ci.org/ONSdigital/go-ns.svg?branch=master)
 
 The following library changes have been made as part of deprecating this repo:
 
-* The `rhttp` client has been removed and should no longer be used.  Any usage of `rhttp` should be replaced by `rchttp`.
-* The `rchttp` client has been moved to a new repo [dp-rchttp](https://github.com/ONSdigital/dp-rchttp).  All imports should be updated accordingly.
+* The `rhttp` client has been removed and should no longer be used.  Any usage of `rhttp` should be replaced by [dp-net/http](https://github.com/ONSdigital/dp-net).
+* The `rchttp` client has been moved to a new repo [dp-net/http](https://github.com/ONSdigital/dp-net).  All imports should be updated accordingly.
 * The API clients have been moved to a new repo [dp-api-clients-go](https://github.com/ONSdigital/dp-api-clients-go/).  All imports should be updated accordingly.
 * The `healthcheck` library has been moved to a new repo [dp-healthcheck](https://github.com/ONSdigital/dp-healthcheck) and updated inline with the [latest spec](https://github.com/ONSdigital/dp/blob/master/standards/HEALTH_CHECK_SPECIFICATION.md). All apps should be updated to use the new health check implementation.
 * The `healthcheck` client has been reimplemented inline with the [latest spec](https://github.com/ONSdigital/dp/blob/master/standards/HEALTH_CHECK_SPECIFICATION.md) in [dp-api-clients-go/health](https://github.com/ONSdigital/dp-api-clients-go/tree/master/health). All clients in `dp-api-clients-go` have been updated to use this new library so all apps should be updated to use these new clients.
@@ -20,6 +20,9 @@ The following library changes have been made as part of deprecating this repo:
 * The `s3` client has been moved to [dp-s3](https://github.com/ONSdigital/dp-s3). All imports should be updated accordingly.
 * The `vault` client has been moved to [dp-vault](https://github.com/ONSdigital/dp-vault). All imports should be updated accordingly.
 * The `log` library has been replaced by [log.go](https://github.com/ONSdigital/log.go) which has been implemented in line with the new [logging standards](https://github.com/ONSdigital/dp/blob/master/standards/LOGGING_STANDARDS.md). A [script is provided](https://github.com/ONSdigital/log.go/blob/master/scripts/edit-logs.sh) to automate the replacement of the log library in most common usages.
+* The `common` library has been moved to [dp-net/http](https://github.com/ONSdigital/dp-net). All imports should be updated accordingly.
+* The `server` library has been moved to [dp-net/http](https://github.com/ONSdigital/dp-net). All imports should be updated accordingly.
+* The `handlers` library has been moved to [dp-net/handlers](https://github.com/ONSdigital/dp-net). All imports should be updated accordingly.
 
 ---
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -109,7 +109,14 @@ func TestNew(t *testing.T) {
 			go func() {
 				s.ListenAndServeTLS("testdata/certFile", "testdata/keyFile")
 			}()
-			http.Get("http://localhost" + sPort) // ensure above is responding before we check below
+			for {
+				_, err := http.Get("http://localhost" + sPort) // ensure above is responding before we check below
+				if err != nil {
+					time.Sleep(100 * time.Millisecond)
+					continue
+				}
+				break
+			}
 			So(s.CertFile, ShouldEqual, "testdata/certFile")
 			So(s.KeyFile, ShouldEqual, "testdata/keyFile")
 		})


### PR DESCRIPTION
### What

- Updated deprecation notes in README according to the packages that have been migrated to `dp-net`
- Traves to go version 1.13, and removed -race flag for tests

### How to review

- Make sure deprecation notes are clear

### Who can review

Anyone