### PR TITLE
Update READMEs to make deprecations clearer and detail whats left

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The following library changes have been made as part of deprecating this repo:
 * The `healthcheck` handler has been reimplemented inline with the [latest spec](https://github.com/ONSdigital/dp/blob/master/standards/HEALTH_CHECK_SPECIFICATION.md) in [dp-healthcheck](https://github.com/ONSdigital/dp-healthcheck). All `/healthcheck` routes should be changed to `/health` and updated to use this new handler.
 * The `elasticsearch` client has been moved to [dp-elasticsearch](https://github.com/ONSdigital/dp-elasticsearch). All imports should be updated accordingly.
 * The `kafka` client has been moved to [dp-kafka](https://github.com/ONSdigital/dp-kafka). All imports should be updated accordingly.
+* The `avro` library has been moved to [dp-kafka/avro](https://github.com/ONSdigital/dp-kafka). All imports should be updated accordingly.
 * The `mongo` client has been moved to [dp-mongodb](https://github.com/ONSdigital/dp-mongodb). All imports should be updated accordingly.
 * The `neo4j` client has been moved to [dp-graph](https://github.com/ONSdigital/dp-graph). All usages of the old `neo4j` library should be replaced with `dp-graph` using the `neo4jdriver`.
 * The `s3` client has been moved to [dp-s3](https://github.com/ONSdigital/dp-s3). All imports should be updated accordingly.
@@ -25,6 +26,13 @@ The following library changes have been made as part of deprecating this repo:
 * The `request` library has been moved to [dp-net/http](https://github.com/ONSdigital/dp-net). All imports should be updated accordingly.
 * The `handlers` library has been moved to [dp-net/handlers](https://github.com/ONSdigital/dp-net). All imports should be updated accordingly.
 * The `identity` library has been moved to [dp-net/handlers](https://github.com/ONSdigital/dp-net). All imports should be updated accordingly.
+
+TODO:
+- Replace remaining uses of `avro`, `common` and `server` packages throughout apps
+- Once new rendering strategy is realized `render` can be deprecated
+- `handlers/requestID` can be removed once all uses of `server` package have been update AND the new rendering strategy exists
+- `handlers/reverseProxy` can be removed once updated in Florence and Frontend Router
+
 
 ---
 

--- a/audit/README.md
+++ b/audit/README.md
@@ -1,5 +1,8 @@
 ## Auditing
 
+### **_DEPRECATED_**
+#### **No longer used**
+
 ### Creating an auditor
 
 To create a new auditor simply provide a Kafka producer (see go-ns/kafka) for the topic you wish to send your audit 

--- a/identity/README.md
+++ b/identity/README.md
@@ -1,6 +1,9 @@
 Identity middleware
 ===================
 
+### **_DEPRECATED_**
+#### **No longer used**
+
 Middleware component that authenticates requests against zebedee.
 
 The identity and permissions returned from the identity endpoint are added to the request context.

--- a/validator/README.md
+++ b/validator/README.md
@@ -1,5 +1,7 @@
 ### Validator
 
+### **_DEPRECATED_**
+### **_No longer used_**
 A Go library for the validation of HTML forms on the server side. Requires user
 to define validation logic of form fields in a JSON file to allow potential
 validation sharing with the client side.


### PR DESCRIPTION
### What

It can be hard to tell where this deprecated library is still being used, and whether specific packages have all been end-of-lifed. Once the whole repo is no longer used it can be moved to officially archived, so it's important we're able to tell when that day has come.

I've run finds on all our repos to ascertain remaining usages of go-ns, and tidied up a few places where certain libraries were only being used in 1 place. This has reduced the remaining footprint go-ns has in our stack. 

This PR updates the documentation to make those deprecations of packages clearer, and also provide documentation as to exactly what is still in use and when the repo can be archived.

### How to review

Check no other usages of go-ns can be found in develop/main branches.

### Who can review

anyone
